### PR TITLE
chore: (#35) configurar GitHub Environments y workflows de deploy staging/production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,44 @@
+# deploy-production.yml
+#
+# Secrets required (configure in GitHub → Settings → Environments → production):
+#   RAILWAY_TOKEN         — Railway API token with deploy access
+#   RAILWAY_SERVICE_ID    — ID of the Railway service to deploy
+#
+# Promotion from staging:
+#   Merge `develop` into `main`. This workflow triggers automatically on push
+#   to `main`, deploying the exact SHA that was validated in staging.
+#   If the `production` environment has required reviewers configured in GitHub,
+#   the deployment will pause for manual approval before executing.
+#
+# Rollback:
+#   Use `workflow_dispatch` on this workflow and select the previous stable SHA
+#   from the branch/tag dropdown. The deploy step will run against that SHA.
+
+name: Deploy — Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Traceability log
+        run: |
+          echo "Deploying SHA ${{ github.sha }} to production at $(date -u)"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+
+      - name: Deploy to Railway (production)
+        run: echo "Deploy to production - SHA: ${{ github.sha }}"
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,42 @@
+# deploy-staging.yml
+#
+# Secrets required (configure in GitHub → Settings → Environments → staging):
+#   RAILWAY_TOKEN         — Railway API token with deploy access
+#   RAILWAY_SERVICE_ID    — ID of the Railway service to deploy
+#
+# Promotion to production:
+#   Merge the same commit to `main`. The deploy-production workflow will run
+#   on that SHA automatically, ensuring bit-for-bit promotion.
+#
+# Rollback:
+#   Use `workflow_dispatch` on deploy-production.yml selecting the previous
+#   stable SHA, or revert the merge commit on `develop` and let this workflow
+#   run again.
+
+name: Deploy — Staging
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Traceability log
+        run: |
+          echo "Deploying SHA ${{ github.sha }} to staging at $(date -u)"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+
+      - name: Deploy to Railway (staging)
+        run: echo "Deploy to staging - SHA: ${{ github.sha }}"
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID }}


### PR DESCRIPTION
## 📋 Descripción

Configura los GitHub Environments (`staging` y `production`) y los workflows de deploy correspondientes, estableciendo el gate de aprobación manual para producción y el deploy automático para staging.

Los pasos de deploy son placeholders hasta que Railway esté configurado (issue de infraestructura pendiente).

Closes #35

---

## 🎯 Cambios incluidos

### Nuevos archivos
- `.github/workflows/deploy-staging.yml` — trigger en `push` a `develop`, environment `staging`, trazabilidad de SHA + timestamp
- `.github/workflows/deploy-production.yml` — trigger en `push` a `main` + `workflow_dispatch`, environment `production` (gate de aprobación manual), trazabilidad de SHA + timestamp

---

## ✅ Criterios de aceptación

- [x] Workflow de staging se ejecuta automáticamente en `push` a `develop`
- [x] Workflow de producción se ejecuta desde `main` con soporte para `workflow_dispatch`
- [x] Ambos workflows usan `environment:` para activar el gate de GitHub Environments
- [x] `production` requiere aprobación manual (configurado en GitHub Settings > Environments)
- [x] Los secrets están separados por environment (`staging` ≠ `production`)
- [x] Los workflows dejan trazabilidad del despliegue (commit SHA + actor + ref + timestamp UTC)
- [ ] Deploy real a Railway — pendiente hasta que Railway esté configurado

---

## 🔍 Notas para el revisor

- El paso de deploy es un `echo` placeholder intencionado. El workflow pasa en verde sin necesidad de Railway ni secrets configurados todavía.
- El gate de aprobación manual de `production` lo activa GitHub automáticamente cuando el environment tiene **Required reviewers** configurados — no requiere ningún step adicional en el workflow.
- Los secrets `RAILWAY_TOKEN` y `RAILWAY_SERVICE_ID` se añadirán a cada environment cuando se configure Railway en la issue de infraestructura correspondiente.
- Estrategia de rollback: usar `workflow_dispatch` en `deploy-production.yml` seleccionando el SHA anterior desde la UI de GitHub Actions.

---

## 🔗 Referencias

- Issue: #35
- Feature padre: #27
- Epic: EPIC-T00 — Enabler (infraestructura y estabilidad)
- Milestone: Hito 1 — MVP Crítico