### PR TITLE
Task/p01 05 01 profile get update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ package-lock.json
 # git add .github/workflows/claude.yml
 # git commit -m "chore: add Claude Code GitHub Actions workflow"
 openspec/*
+pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ package-lock.json
 # Si luego se quiere añadir:
 # git add .github/workflows/claude.yml
 # git commit -m "chore: add Claude Code GitHub Actions workflow"
+openspec/*

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -107,6 +107,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /profile/me:
+    get:
+      operationId: getMyProfile
+      summary: Get current user profile
+      tags:
+        - Profile
+      responses:
+        '200':
+          description: Profile returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Profile not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      operationId: updateMyProfile
+      summary: Update current user profile
+      tags:
+        - Profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProfileRequest'
+      responses:
+        '200':
+          description: Profile updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /auth/refresh:
     post:
       operationId: refreshToken
@@ -204,7 +260,7 @@ components:
       properties:
         accessToken:
           type: string
-          description: "Short-lived JWT access token (Authorization: Bearer)"
+          description: 'Short-lived JWT access token (Authorization: Bearer)'
           example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
         refreshToken:
           type: string
@@ -245,3 +301,67 @@ components:
                 type: string
               message:
                 type: string
+
+    Profile:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Profile ID
+          example: 550e8400-e29b-41d4-a716-446655440000
+        userId:
+          type: string
+          format: uuid
+          description: User ID
+          example: 550e8400-e29b-41d4-a716-446655440000
+        displayName:
+          type: string
+          description: Display name (nombre visible)
+          example: Alex García
+        bio:
+          type: string
+          description: Short bio
+          nullable: true
+          example: Hola, soy Alex!
+        avatarUrl:
+          type: string
+          description: Avatar URL
+          nullable: true
+          example: https://cdn.tribehub.app/avatars/user_123/avatar.png
+        isPublic:
+          type: boolean
+          description: Whether profile is public
+          example: true
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T00:00:00.000Z
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T00:00:00.000Z
+
+    UpdateProfileRequest:
+      type: object
+      required:
+        - displayName
+      properties:
+        displayName:
+          type: string
+          minLength: 2
+          maxLength: 50
+          description: Display name (nombre visible)
+          example: Alex García
+        bio:
+          type: string
+          maxLength: 160
+          description: Short bio (optional)
+          nullable: true
+          example: Hola, soy Alex!
+        avatarUrl:
+          type: string
+          format: uri
+          description: Avatar URL (optional)
+          nullable: true
+          example: https://cdn.tribehub.app/avatars/user_123/avatar.png

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dotenv": "^17.3.1",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^4.0.1",
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
+      jwks-rsa:
+        specifier: ^4.0.1
+        version: 4.0.1
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -1852,11 +1855,17 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/markdown-escape@1.1.3':
     resolution: {integrity: sha512-JIc1+s3y5ujKnt/+N+wq6s/QdL2qZ11fP79MijrVXsAAnzSxCbT2j/3prHRouJdZ2yFLN3vkP0HytfnoCczjOw==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
@@ -3492,6 +3501,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3548,6 +3560,10 @@ packages:
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
+  jwks-rsa@4.0.1:
+    resolution: {integrity: sha512-poXwUA8S4cP9P5N8tZS3xnUDJH8WmwSGfKK9gIaRPdjLHyJtd9iX/cngX9CUIe0Caof5JhK2EbN7N5lnnaf9NA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >= 23.0.0}
+
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
@@ -3569,6 +3585,9 @@ packages:
   libphonenumber-js@1.12.41:
     resolution: {integrity: sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==}
 
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -3587,6 +3606,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -3644,6 +3666,9 @@ packages:
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
+
+  lru-memoizer@3.0.0:
+    resolution: {integrity: sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==}
 
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
@@ -6791,9 +6816,16 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.15
+
   '@types/markdown-escape@1.1.3': {}
 
   '@types/methods@1.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.27':
     dependencies:
@@ -8699,6 +8731,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -8756,6 +8790,16 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  jwks-rsa@4.0.1:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      debug: 4.4.3
+      jose: 6.2.2
+      limiter: 1.1.5
+      lru-memoizer: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   jws@4.0.1:
     dependencies:
       jwa: 2.0.1
@@ -8776,6 +8820,8 @@ snapshots:
 
   libphonenumber-js@1.12.41: {}
 
+  limiter@1.1.5: {}
+
   lines-and-columns@1.2.4: {}
 
   load-esm@1.0.3: {}
@@ -8787,6 +8833,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.clonedeep@4.5.0: {}
 
   lodash.defaults@4.2.0: {}
 
@@ -8826,6 +8874,11 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
+
+  lru-memoizer@3.0.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 11.2.7
 
   lru.min@1.1.4: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { FeedModule } from './modules/feed/feed.module';
 import { SearchModule } from './modules/search/search.module';
 import { QueuesModule } from './queues/queues.module';
 import { BullboardModule } from './admin/queues/bullboard.module';
+import { ProfileModule } from './modules/profile/profile.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { BullboardModule } from './admin/queues/bullboard.module';
     SearchModule,
     QueuesModule,
     BullboardModule,
+    ProfileModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/auth/guards/supabase-auth.guard.ts
+++ b/src/auth/guards/supabase-auth.guard.ts
@@ -6,22 +6,41 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
-import { verify, type JwtPayload } from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
+import jwksRsa from 'jwks-rsa';
+import type { JwksClient } from 'jwks-rsa';
 import { SecurityMonitorService } from '../../observability/alerts/security-monitor.service';
-
-const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET;
+import { PrismaService } from '../../prisma/prisma.service';
 
 type AuthenticatedRequest = Request & {
-  supabaseUser: JwtPayload;
+  supabaseUser: jwt.JwtPayload;
   supabaseToken: string;
+  /** Internal user ID from public.users table */
+  userId?: string;
 };
 
 @Injectable()
 export class SupabaseAuthGuard implements CanActivate {
-  constructor(private readonly securityMonitor: SecurityMonitorService) {}
+  private readonly jwksClient: JwksClient;
 
-  canActivate(context: ExecutionContext): boolean {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly securityMonitor: SecurityMonitorService,
+    private readonly prisma: PrismaService,
+  ) {
+    // Initialize JWKS client for ES256 tokens from Supabase
+    const supabaseUrl = this.configService.getOrThrow<string>('SUPABASE_URL');
+    this.jwksClient = jwksRsa({
+      jwksUri: `${supabaseUrl}/auth/v1/.well-known/jwks.json`,
+      cache: true,
+      cacheMaxEntries: 5,
+      cacheMaxAge: 600000, // 10 minutes
+    });
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
     const authHeader = request.headers['authorization'];
 
@@ -37,30 +56,99 @@ export class SupabaseAuthGuard implements CanActivate {
       throw new UnauthorizedException('Missing token');
     }
 
-    if (!SUPABASE_JWT_SECRET) {
-      throw new UnauthorizedException('JWT secret not configured');
-    }
-
-    // Validate Supabase JWT
+    // Validate Supabase ES256 JWT using JWKS
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const decoded = verify(token, SUPABASE_JWT_SECRET) as JwtPayload;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      request.supabaseUser = decoded;
+      // First, decode the token header to get the key ID (kid)
+      const decodedHeader = jwt.decode(token, { complete: true });
+      if (!decodedHeader || typeof decodedHeader === 'string') {
+        throw new UnauthorizedException('Malformed token');
+      }
+
+      const header = decodedHeader.header as { kid?: string; alg?: string };
+      if (!header.kid) {
+        throw new UnauthorizedException('Token missing key ID');
+      }
+
+      // Get the signing key from JWKS
+      const signingKey = await this.jwksClient.getSigningKey(header.kid);
+      const publicKey = signingKey.getPublicKey();
+
+      if (!publicKey) {
+        throw new UnauthorizedException('Unable to get signing key');
+      }
+
+      // Verify the token with the public key
+      const payload = jwt.verify(token, publicKey, {
+        algorithms: ['ES256'],
+      }) as jwt.JwtPayload;
+
+      // Sync Supabase user to public.users if not exists
+      const internalUserId = await this.syncUserToPublicTable(payload);
+      (request as AuthenticatedRequest).userId = internalUserId;
+
+      request.supabaseUser = payload;
       request.supabaseToken = token;
       return true;
     } catch (err) {
       this.securityMonitor.recordInvalidToken();
       const name = err instanceof Error ? err.name : '';
+      const message = err instanceof Error ? err.message : '';
+
       if (name === 'TokenExpiredError') {
         throw new UnauthorizedException('Token expired');
       } else if (name === 'NotBeforeError') {
         throw new UnauthorizedException('Token not active');
-      } else if (name === 'JsonWebTokenError') {
+      } else if (name === 'JsonWebTokenError' || message.includes('invalid')) {
         throw new UnauthorizedException('Malformed token or invalid signature');
+      } else if (err instanceof UnauthorizedException) {
+        throw err;
       } else {
         throw new UnauthorizedException('JWT authentication error');
       }
+    }
+  }
+
+  /**
+   * Synchronize user from Supabase Auth to public.users table.
+   * Ensures the user exists in our database before protected routes run.
+   * Returns the internal user ID.
+   */
+  private async syncUserToPublicTable(
+    payload: jwt.JwtPayload,
+  ): Promise<string | undefined> {
+    const supabaseId = payload.sub as string;
+    const email = payload.email as string;
+
+    if (!supabaseId || !email) {
+      return undefined;
+    }
+
+    try {
+      const username =
+        (payload.user_metadata?.username as string) ||
+        email.split('@')[0] ||
+        `user_${supabaseId.slice(0, 8)}`;
+
+      // Use Prisma's upsert directly
+      const result = await this.prisma.user.upsert({
+        where: { supabaseId },
+        create: {
+          supabaseId,
+          email,
+          username,
+          status: 'ACTIVE',
+        },
+        update: {
+          email,
+        },
+      });
+
+      return result.id;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      console.warn(`User sync failed for ${supabaseId}: ${errorMessage}`);
+      return undefined;
     }
   }
 }

--- a/src/common/types/authenticated-request.type.ts
+++ b/src/common/types/authenticated-request.type.ts
@@ -1,0 +1,17 @@
+// src/common/types/authenticated-request.type.ts
+
+import { Request } from 'express';
+import { JwtPayload } from 'jsonwebtoken';
+
+/**
+ * Extended Request type for authenticated users via Supabase JWT.
+ * The SupabaseAuthGuard populates these fields after validating the token.
+ */
+export type AuthenticatedRequest = Request & {
+  /** Decoded JWT payload from Supabase. Contains `sub` as user ID. */
+  supabaseUser: JwtPayload;
+  /** Raw JWT token string for downstream use (e.g., refresh). */
+  supabaseToken: string;
+  /** Internal user ID from public.users table (sync by guard) */
+  userId?: string;
+};

--- a/src/modules/profile/dto/update-profile.dto.ts
+++ b/src/modules/profile/dto/update-profile.dto.ts
@@ -1,0 +1,46 @@
+// src/modules/profile/dto/update-profile.dto.ts
+
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+import { Transform } from 'class-transformer';
+
+/**
+ * DTO for updating the user's profile (base/onboarding).
+ *
+ * Validation rules:
+ * - displayName: required, 2-50 chars, permite letras (incluyendo tildes/unicode), espacios y guiones
+ * - bio: optional, max 160 chars
+ * - avatarUrl: optional, valid URL
+ */
+export class UpdateProfileDto {
+  @IsString()
+  @MinLength(2, {
+    message: 'Display name must be at least 2 characters',
+  })
+  @MaxLength(50, {
+    message: 'Display name must be at most 50 characters',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  displayName: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(160, {
+    message: 'Bio must be at most 160 characters',
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  bio?: string;
+
+  @IsOptional()
+  @IsUrl({
+    protocols: ['https', 'http'],
+    require_tld: true,
+  })
+  avatarUrl?: string;
+}

--- a/src/modules/profile/profile.controller.spec.ts
+++ b/src/modules/profile/profile.controller.spec.ts
@@ -1,0 +1,70 @@
+// src/modules/profile/profile.controller.spec.ts
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ProfileController } from './profile.controller';
+
+const mockProfileService = {
+  getProfile: vi.fn(),
+  updateProfile: vi.fn(),
+};
+
+describe('ProfileController', () => {
+  let controller: ProfileController;
+  const mockRequest = {
+    userId: 'user-123',
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new ProfileController(mockProfileService as never);
+  });
+
+  describe('getProfile', () => {
+    it('returns the user profile', async () => {
+      const profile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Alex',
+        bio: 'Hello!',
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockProfileService.getProfile.mockResolvedValue(profile);
+
+      const result = await controller.getProfile(mockRequest);
+
+      expect(result).toEqual(profile);
+      expect(mockProfileService.getProfile).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('updates and returns the profile', async () => {
+      const dto = {
+        displayName: 'Alex García',
+        bio: 'Updated bio',
+      };
+      const profile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Alex García',
+        bio: 'Updated bio',
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockProfileService.updateProfile.mockResolvedValue(profile);
+
+      const result = await controller.updateProfile(mockRequest, dto);
+
+      expect(result).toEqual(profile);
+      expect(mockProfileService.updateProfile).toHaveBeenCalledWith(
+        'user-123',
+        dto,
+      );
+    });
+  });
+});

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,0 +1,90 @@
+// src/modules/profile/profile.controller.ts
+
+import {
+  Controller,
+  Get,
+  Patch,
+  Body,
+  Req,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { ProfileService } from './profile.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { AuthenticatedRequest } from '../../common/types/authenticated-request.type';
+import { SupabaseAuthGuard } from '../../auth/guards/supabase-auth.guard';
+
+/**
+ * Controller for profile endpoints.
+ * Protected by SupabaseAuthGuard - all routes require authentication.
+ */
+@ApiTags('Profile')
+@ApiBearerAuth()
+@Controller('profile')
+@UseGuards(SupabaseAuthGuard)
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  /**
+   * GET /v1/profile/me
+   * Get the current user's profile.
+   */
+  @Get('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile returned',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  async getProfile(@Req() request: AuthenticatedRequest) {
+    // Use internal user ID from the guard sync
+    const userId = request.userId;
+    if (!userId) {
+      throw new UnauthorizedException('User not found');
+    }
+    return this.profileService.getProfile(userId);
+  }
+
+  /**
+   * PATCH /v1/profile/me
+   * Update the current user's profile.
+   */
+  @Patch('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update current user profile' })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile updated',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  async updateProfile(
+    @Req() request: AuthenticatedRequest,
+    @Body() dto: UpdateProfileDto,
+  ) {
+    // Use internal user ID from the guard sync
+    const userId = request.userId;
+    if (!userId) {
+      throw new UnauthorizedException('User not found');
+    }
+    return this.profileService.updateProfile(userId, dto);
+  }
+}

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -1,0 +1,19 @@
+// src/modules/profile/profile.module.ts
+
+import { Module } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { ProfileRepository } from './repositories/profile.repository';
+import { ObservabilityModule } from '../../observability/observability.module';
+
+/**
+ * Profile module for user profile management.
+ * Provides endpoints for getting and updating user profile (onboarding).
+ */
+@Module({
+  imports: [ObservabilityModule],
+  controllers: [ProfileController],
+  providers: [ProfileService, ProfileRepository],
+  exports: [ProfileService, ProfileRepository],
+})
+export class ProfileModule {}

--- a/src/modules/profile/profile.service.spec.ts
+++ b/src/modules/profile/profile.service.spec.ts
@@ -1,0 +1,139 @@
+// src/modules/profile/profile.service.spec.ts
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+
+const mockProfileRepository = {
+  findByUserId: vi.fn(),
+  upsert: vi.fn(),
+  update: vi.fn(),
+};
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ProfileService(mockProfileRepository as never);
+  });
+
+  describe('getProfile', () => {
+    it('returns profile when found', async () => {
+      const profile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Alex',
+        bio: 'Hello!',
+        avatarUrl: 'https://example.com/avatar.png',
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockProfileRepository.findByUserId.mockResolvedValue(profile);
+
+      const result = await service.getProfile('user-123');
+
+      expect(result).toEqual(profile);
+      expect(mockProfileRepository.findByUserId).toHaveBeenCalledWith(
+        'user-123',
+      );
+    });
+
+    it('throws NotFoundException when profile not found', async () => {
+      mockProfileRepository.findByUserId.mockResolvedValue(null);
+
+      await expect(service.getProfile('user-missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('creates profile when it does not exist', async () => {
+      const dto = {
+        displayName: 'Alex García',
+        bio: 'Hello!',
+        avatarUrl: 'https://example.com/avatar.png',
+      };
+      const createdProfile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Alex García',
+        bio: 'Hello!',
+        avatarUrl: 'https://example.com/avatar.png',
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockProfileRepository.findByUserId.mockResolvedValue(null);
+      mockProfileRepository.upsert.mockResolvedValue(createdProfile);
+
+      const result = await service.updateProfile('user-123', dto);
+
+      expect(result).toEqual(createdProfile);
+      expect(mockProfileRepository.upsert).toHaveBeenCalledWith('user-123', {
+        displayName: 'Alex García',
+        bio: 'Hello!',
+        avatarUrl: 'https://example.com/avatar.png',
+      });
+    });
+
+    it('updates existing profile with partial data', async () => {
+      const dto = {
+        displayName: 'New Name',
+      };
+      const existingProfile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Old Name',
+        bio: 'Old bio',
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const updatedProfile = {
+        ...existingProfile,
+        displayName: 'New Name',
+      };
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+      mockProfileRepository.update.mockResolvedValue(updatedProfile);
+
+      const result = await service.updateProfile('user-123', dto);
+
+      expect(result).toEqual(updatedProfile);
+      expect(mockProfileRepository.update).toHaveBeenCalledWith('user-123', {
+        displayName: 'New Name',
+      });
+    });
+
+    it('only updates displayName when bio is omitted', async () => {
+      const dto = {
+        displayName: 'Alex',
+      };
+      const existingProfile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Old Name',
+        bio: 'Old bio',
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+      mockProfileRepository.update.mockResolvedValue({
+        ...existingProfile,
+        displayName: 'Alex',
+      });
+
+      await service.updateProfile('user-123', dto);
+
+      // Only displayName is updated - bio is not included when omitted
+      expect(mockProfileRepository.update).toHaveBeenCalledWith('user-123', {
+        displayName: 'Alex',
+      });
+    });
+  });
+});

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -1,0 +1,86 @@
+// src/modules/profile/profile.service.ts
+
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ProfileRepository } from './repositories/profile.repository';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+/**
+ * Service for profile business logic.
+ * Handles get/update operations with logging.
+ */
+@Injectable()
+export class ProfileService {
+  private readonly logger = new Logger(ProfileService.name);
+
+  constructor(private readonly profileRepository: ProfileRepository) {}
+
+  /**
+   * Get profile by userId.
+   * Throws NotFoundException if profile doesn't exist.
+   */
+  async getProfile(userId: string) {
+    const profile = await this.profileRepository.findByUserId(userId);
+
+    if (!profile) {
+      throw new NotFoundException('Profile not found');
+    }
+
+    this.logger.log({
+      message: 'profile.get_me',
+      userId,
+    });
+
+    return profile;
+  }
+
+  /**
+   * Update profile with the provided data.
+   * Creates profile if it doesn't exist (onboarding flow).
+   */
+  async updateProfile(userId: string, dto: UpdateProfileDto) {
+    // Check if profile exists
+    const existing = await this.profileRepository.findByUserId(userId);
+
+    if (!existing) {
+      // Create initial profile (onboarding)
+      const profile = await this.profileRepository.upsert(userId, {
+        displayName: dto.displayName,
+        bio: dto.bio ?? null,
+        avatarUrl: dto.avatarUrl ?? null,
+      });
+
+      this.logger.log({
+        message: 'profile.created',
+        userId,
+      });
+
+      return profile;
+    }
+
+    // Update existing profile (partial update)
+    const updateData: {
+      displayName?: string;
+      bio?: string | null;
+      avatarUrl?: string | null;
+    } = {};
+
+    if (dto.displayName !== undefined) {
+      updateData.displayName = dto.displayName;
+    }
+    if (dto.bio !== undefined) {
+      updateData.bio = dto.bio ?? null;
+    }
+    if (dto.avatarUrl !== undefined) {
+      updateData.avatarUrl = dto.avatarUrl ?? null;
+    }
+
+    const profile = await this.profileRepository.update(userId, updateData);
+
+    this.logger.log({
+      message: 'profile.updated',
+      userId,
+    });
+
+    return profile;
+  }
+}

--- a/src/modules/profile/repositories/profile.repository.spec.ts
+++ b/src/modules/profile/repositories/profile.repository.spec.ts
@@ -1,0 +1,141 @@
+// src/modules/profile/repositories/profile.repository.spec.ts
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ProfileRepository } from './profile.repository';
+
+const mockPrismaProfile = {
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+  update: vi.fn(),
+};
+
+const mockPrismaService = {
+  profile: mockPrismaProfile,
+};
+
+describe('ProfileRepository', () => {
+  let repository: ProfileRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = new ProfileRepository(mockPrismaService as never);
+  });
+
+  describe('findByUserId', () => {
+    it('calls prisma.profile.findUnique with the userId', async () => {
+      mockPrismaProfile.findUnique.mockResolvedValue(null);
+
+      await repository.findByUserId('user-123');
+
+      expect(mockPrismaProfile.findUnique).toHaveBeenCalledOnce();
+      expect(mockPrismaProfile.findUnique).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+      });
+    });
+
+    it('returns the profile when found', async () => {
+      const profile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'Alex',
+        bio: null,
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaProfile.findUnique.mockResolvedValue(profile);
+
+      const result = await repository.findByUserId('user-123');
+
+      expect(result).toEqual(profile);
+    });
+
+    it('returns null when profile is not found', async () => {
+      mockPrismaProfile.findUnique.mockResolvedValue(null);
+
+      const result = await repository.findByUserId('user-missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('upsert', () => {
+    it('calls prisma.profile.upsert with create data when profile does not exist', async () => {
+      const input = {
+        displayName: 'Alex García',
+        bio: 'Hello!',
+        avatarUrl: null,
+      };
+      const expectedProfile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        ...input,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaProfile.upsert.mockResolvedValue(expectedProfile);
+
+      const result = await repository.upsert('user-123', input);
+
+      expect(mockPrismaProfile.upsert).toHaveBeenCalledOnce();
+      expect(mockPrismaProfile.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        create: { userId: 'user-123', ...input },
+        update: input,
+      });
+      expect(result).toEqual(expectedProfile);
+    });
+
+    it('calls prisma.profile.upsert with update data when profile exists', async () => {
+      const input = {
+        displayName: 'Updated Name',
+        bio: 'New bio',
+      };
+      mockPrismaProfile.upsert.mockResolvedValue({
+        id: 'profile-1',
+        userId: 'user-123',
+        ...input,
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await repository.upsert('user-123', input);
+
+      expect(mockPrismaProfile.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        create: { userId: 'user-123', ...input },
+        update: input,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('calls prisma.profile.update with partial data', async () => {
+      const input = { displayName: 'New Name' };
+      const expectedProfile = {
+        id: 'profile-1',
+        userId: 'user-123',
+        displayName: 'New Name',
+        bio: null,
+        avatarUrl: null,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrismaProfile.update.mockResolvedValue(expectedProfile);
+
+      const result = await repository.update('user-123', input);
+
+      expect(mockPrismaProfile.update).toHaveBeenCalledOnce();
+      expect(mockPrismaProfile.update).toHaveBeenCalledWith({
+        where: { userId: 'user-123' },
+        data: input,
+      });
+      expect(result).toEqual(expectedProfile);
+    });
+  });
+});

--- a/src/modules/profile/repositories/profile.repository.ts
+++ b/src/modules/profile/repositories/profile.repository.ts
@@ -1,0 +1,65 @@
+// src/modules/profile/repositories/profile.repository.ts
+
+import { Injectable } from '@nestjs/common';
+import type { PrismaClient, Profile } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+/**
+ * Repository for Profile data access.
+ * Follows the same pattern as AuthRepository and UsersRepository.
+ */
+@Injectable()
+export class ProfileRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Find profile by userId.
+   * Returns null if profile doesn't exist.
+   */
+  async findByUserId(userId: string): Promise<Profile | null> {
+    const client = this.prisma as unknown as PrismaClient;
+    return client.profile.findUnique({
+      where: { userId },
+    });
+  }
+
+  /**
+   * Create or update a profile (upsert pattern).
+   * Used for initial profile creation during onboarding.
+   */
+  async upsert(
+    userId: string,
+    data: {
+      displayName: string;
+      bio?: string | null;
+      avatarUrl?: string | null;
+    },
+  ): Promise<Profile> {
+    const client = this.prisma as unknown as PrismaClient;
+    return client.profile.upsert({
+      where: { userId },
+      create: { userId, ...data },
+      update: data,
+    });
+  }
+
+  /**
+   * Update existing profile fields.
+   * Only updates provided fields (partial update).
+   */
+  async update(
+    userId: string,
+    data: {
+      displayName?: string;
+      bio?: string | null;
+      avatarUrl?: string | null;
+      isPublic?: boolean;
+    },
+  ): Promise<Profile> {
+    const client = this.prisma as unknown as PrismaClient;
+    return client.profile.update({
+      where: { userId },
+      data,
+    });
+  }
+}


### PR DESCRIPTION
## 🎯 Objetivo
Implementación de los endpoints del backend para obtener y actualizar el perfil base del usuario autenticado (Onboarding). 
Subtarea de: #29 (F-P01-05)
Cierra: #82
## 🛠️ Cambios realizados
- Modelo `Profile` existente en Prisma (displayName, bio, avatarUrl, isPublic).
- Implementación de `GET /api/v1/profile/me` para obtener el perfil del usuario autenticado.
- Implementación de `PATCH /api/v1/profile/me` con validación DTO (displayName 2-50 chars, bio max 160).
- Fix: Sincronización de usuario auth.users → public.users en SupabaseAuthGuard (upsert).
- ProfileModule con Repository pattern.
- Pruebas unitarias (13 tests passing).
- Documentación OpenAPI actualizada.
## ✅ Criterios de Aceptación cumplidos
- [x] GET devuelve 200 y el perfil del usuario autenticado
- [x] PATCH valida el DTO y devuelve 200 con perfil actualizado
- [x] Ambos endpoints requieren autenticación (401 si no hay sesión)
- [x] displayName permite espacios y tildes (nombre visible, no username)
- [x] Sincronización automática de usuarios en el guard
<img width="756" height="754" alt="image" src="https://github.com/user-attachments/assets/dbebbbd3-a913-492a-90ac-093ccfeae0d6" />

<img width="743" height="610" alt="image" src="https://github.com/user-attachments/assets/a91e7b29-0836-44c4-9c36-87e922b38a16" />
