### PR TITLE
Feat/p01 03 refresh token csrf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ SUPABASE_JWT_SECRET=tu-supabase-jwt-secret
 # Usa al menos 32 caracteres aleatorios.
 JWT_SECRET=tu-jwt-secret-super-seguro-aqui
 JWT_EXPIRES_IN=7d
+REFRESH_TOKEN_TTL_DAYS=7
 
 # =====================================
 # BASE DE DATOS

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -114,22 +114,40 @@ paths:
       tags:
         - Auth
       security:
-        - BearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RefreshRequest'
+        - RefreshTokenCookie: []
+      parameters:
+        - in: header
+          name: X-CSRF-Token
+          required: true
+          schema:
+            type: string
+          description: CSRF token value from XSRF-TOKEN cookie
       responses:
         '200':
-          description: Tokens rotated successfully
+          description: Tokens rotated successfully. Sets new refresh cookie and XSRF cookie.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginResponse'
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: string
+                  message:
+                    type: string
         '401':
           description: Refresh token invalid, expired, or blacklisted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Invalid CSRF token
           content:
             application/json:
               schema:
@@ -142,12 +160,24 @@ paths:
       tags:
         - Auth
       security:
-        - BearerAuth: []
+        - RefreshTokenCookie: []
+      parameters:
+        - in: header
+          name: X-CSRF-Token
+          required: true
+          schema:
+            type: string
       responses:
         '204':
           description: Session revoked successfully
         '401':
-          description: Missing or invalid access token
+          description: Missing or invalid refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Invalid CSRF token
           content:
             application/json:
               schema:
@@ -159,6 +189,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    RefreshTokenCookie:
+      type: apiKey
+      in: cookie
+      name: refresh_token
 
   schemas:
     RegisterRequest:
@@ -205,20 +239,6 @@ components:
         accessToken:
           type: string
           description: "Short-lived JWT access token (Authorization: Bearer)"
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-        refreshToken:
-          type: string
-          description: Long-lived refresh token used to rotate the session
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-
-    RefreshRequest:
-      type: object
-      required:
-        - refreshToken
-      properties:
-        refreshToken:
-          type: string
-          description: Refresh token obtained at login
           example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
     ErrorResponse:

--- a/prisma/migrations/20260510021000_refresh_token_rotation_csrf/migration.sql
+++ b/prisma/migrations/20260510021000_refresh_token_rotation_csrf/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "refresh_tokens"
+  ADD COLUMN "replacedByTokenId" TEXT,
+  ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "ipAddress" TEXT,
+  ADD COLUMN "userAgent" TEXT;
+
+CREATE INDEX "refresh_tokens_replacedByTokenId_idx" ON "refresh_tokens"("replacedByTokenId");
+
+ALTER TABLE "refresh_tokens"
+  ADD CONSTRAINT "refresh_tokens_replacedByTokenId_fkey"
+  FOREIGN KEY ("replacedByTokenId") REFERENCES "refresh_tokens"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,13 +61,20 @@ model RefreshToken {
   tokenHash        String    @unique // SHA-256 hash del refresh token (nunca texto plano)
   revokedAt        DateTime? // null = activo; valor = revocado
   revocationReason String?   // 'logout' | 'rotation' | 'admin'
+  replacedByTokenId String?
+  updatedAt        DateTime  @updatedAt
   createdAt        DateTime  @default(now())
   expiresAt        DateTime  // Fecha de expiración del token
+  ipAddress        String?
+  userAgent        String?
 
   // Relaciones
   user             User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  replacedByToken  RefreshToken? @relation("RefreshTokenRotation", fields: [replacedByTokenId], references: [id])
+  previousTokens   RefreshToken[] @relation("RefreshTokenRotation")
 
   @@index([userId])
+  @@index([replacedByTokenId])
   @@map("refresh_tokens")
 }
 

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -22,6 +22,7 @@ describe('AuthController', () => {
             register: vi.fn(),
             login: vi.fn(),
             logout: vi.fn(),
+            refreshSession: vi.fn(),
           },
         },
       ],
@@ -63,14 +64,22 @@ describe('AuthController', () => {
       session: { access_token: 'access-jwt', refresh_token: 'refresh-jwt' },
       user: { id: 'user-id', email: 'test@gmail.com' },
     });
+    const req = {
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' },
+    } as unknown as import('express').Request;
+    const res = {
+      cookie: vi.fn(),
+      clearCookie: vi.fn(),
+    } as unknown as import('express').Response;
 
-    const result = await controller.login(dto);
+    const result = await controller.login(dto, req, res);
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
       accessToken: 'access-jwt',
-      refreshToken: 'refresh-jwt',
       user: { id: 'user-id', email: 'test@gmail.com' },
     });
+    expect((res.cookie as Mock).mock.calls.length).toBe(2);
   });
 
   it('should handle login error', async () => {
@@ -80,7 +89,42 @@ describe('AuthController', () => {
     };
     (service.login as Mock).mockRejectedValue(new Error('Login failed'));
 
-    await expect(controller.login(dto)).rejects.toThrowError('Login failed');
+    await expect(
+      controller.login(
+        { ...dto },
+        { headers: {}, ip: '127.0.0.1' } as never,
+        {} as never,
+      ),
+    ).rejects.toThrowError('Login failed');
+  });
+
+  describe('refresh', () => {
+    it('rotates cookie and returns new access token', async () => {
+      (service.refreshSession as Mock).mockResolvedValue({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        refreshExpiresAt: new Date(Date.now() + 1000),
+        csrfToken: 'new-csrf',
+      });
+
+      const req = {
+        cookies: { refresh_token: 'old-refresh' },
+        ip: '127.0.0.1',
+        headers: { 'user-agent': 'vitest' },
+      } as unknown as import('express').Request;
+      const res = {
+        cookie: vi.fn(),
+        clearCookie: vi.fn(),
+      } as unknown as import('express').Response;
+
+      const result = await controller.refresh(req, res);
+
+      expect(result).toMatchObject({
+        success: true,
+        data: { accessToken: 'new-access' },
+      });
+      expect((res.cookie as Mock).mock.calls.length).toBe(2);
+    });
   });
 
   describe('logout', () => {

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -59,11 +59,18 @@ describe('AuthController', () => {
 
   it('should login a user', async () => {
     const dto: LoginDto = { email: 'test@gmail.com', password: 'password123' };
-    (service.login as Mock).mockResolvedValue({ session: 'session-token' });
+    (service.login as Mock).mockResolvedValue({
+      session: { access_token: 'access-jwt', refresh_token: 'refresh-jwt' },
+      user: { id: 'user-id', email: 'test@gmail.com' },
+    });
 
     const result = await controller.login(dto);
     expect(result.success).toBe(true);
-    expect(result.data).toEqual({ session: 'session-token' });
+    expect(result.data).toEqual({
+      accessToken: 'access-jwt',
+      refreshToken: 'refresh-jwt',
+      user: { id: 'user-id', email: 'test@gmail.com' },
+    });
   });
 
   it('should handle login error', async () => {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -10,9 +10,18 @@ import {
   HttpException,
   Req,
   Res,
+  UseGuards,
+  UnauthorizedException,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { randomBytes } from 'crypto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiCookieAuth,
+  ApiHeader,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { RegisterRequestDto } from './dto/register.request.dto';
 import { RegisterResponseDto } from './dto/register.response.dto';
@@ -20,11 +29,18 @@ import { LoginDto } from './dto/login.dto';
 import {
   clearAuthCookies,
   REFRESH_TOKEN_COOKIE,
+  XSRF_TOKEN_COOKIE,
+  buildRefreshTokenCookieOptions,
+  buildCsrfCookieOptions,
 } from '../common/utils/cookies';
+import { CsrfGuard } from './guards/csrf.guard';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
+  private readonly refreshTtlMs =
+    Number(process.env.REFRESH_TOKEN_TTL_DAYS ?? '7') * 24 * 60 * 60 * 1000;
+
   constructor(private readonly authService: AuthService) {}
 
   @ApiOperation({ summary: 'Register a new user' })
@@ -63,14 +79,47 @@ export class AuthController {
   }
 
   @Post('login')
-  async login(@Body() dto: LoginDto) {
+  async login(
+    @Body() dto: LoginDto,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     try {
-      const result = await this.authService.login(dto);
+      const result = await this.authService.login(dto, {
+        ipAddress: req.ip,
+        userAgent:
+          typeof req.headers['user-agent'] === 'string'
+            ? req.headers['user-agent']
+            : undefined,
+      });
+      const refreshToken = result.session?.refresh_token;
+      const accessToken = result.session?.access_token;
+
+      if (!refreshToken || !accessToken) {
+        throw new BadRequestException({
+          code: 'LOGIN_ERROR',
+          message: 'Invalid authentication response',
+        });
+      }
+
+      const refreshExpiresAt = new Date(Date.now() + this.refreshTtlMs);
+      const csrfToken = randomBytes(32).toString('base64url');
+
+      res.cookie(
+        REFRESH_TOKEN_COOKIE,
+        refreshToken,
+        buildRefreshTokenCookieOptions(refreshExpiresAt),
+      );
+      res.cookie(
+        XSRF_TOKEN_COOKIE,
+        csrfToken,
+        buildCsrfCookieOptions(refreshExpiresAt),
+      );
+
       return {
         success: true,
         data: {
-          accessToken: result.session?.access_token ?? null,
-          refreshToken: result.session?.refresh_token ?? null,
+          accessToken,
           user: result.user ?? null,
         },
         message: 'Login successful',
@@ -84,6 +133,57 @@ export class AuthController {
     }
   }
 
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(CsrfGuard)
+  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
+  @ApiHeader({ name: 'X-CSRF-Token', required: true })
+  @ApiResponse({
+    status: 200,
+    description: 'Session refreshed successfully',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  async refresh(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const rawRefreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] as
+      | string
+      | undefined;
+    if (!rawRefreshToken) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const result = await this.authService.refreshSession({
+      rawRefreshToken,
+      ipAddress: req.ip,
+      userAgent:
+        typeof req.headers['user-agent'] === 'string'
+          ? req.headers['user-agent']
+          : undefined,
+    });
+
+    res.cookie(
+      REFRESH_TOKEN_COOKIE,
+      result.refreshToken,
+      buildRefreshTokenCookieOptions(result.refreshExpiresAt),
+    );
+    res.cookie(
+      XSRF_TOKEN_COOKIE,
+      result.csrfToken,
+      buildCsrfCookieOptions(result.refreshExpiresAt),
+    );
+
+    return {
+      success: true,
+      data: {
+        accessToken: result.accessToken,
+      },
+      message: 'Refresh successful',
+    };
+  }
+
   /**
    * POST /auth/logout
    *
@@ -95,6 +195,9 @@ export class AuthController {
    */
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(CsrfGuard)
+  @ApiCookieAuth(REFRESH_TOKEN_COOKIE)
+  @ApiHeader({ name: 'X-CSRF-Token', required: true })
   async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const rawToken = req.cookies?.[REFRESH_TOKEN_COOKIE] as string | undefined;
     await this.authService.logout(rawToken);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -68,7 +68,11 @@ export class AuthController {
       const result = await this.authService.login(dto);
       return {
         success: true,
-        data: result,
+        data: {
+          accessToken: result.session?.access_token ?? null,
+          refreshToken: result.session?.refresh_token ?? null,
+          user: result.user ?? null,
+        },
         message: 'Login successful',
       };
     } catch (error) {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,13 +5,14 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { AuthRepository } from './repositories/auth.repository';
 import { SupabaseAuthGuard } from './guards/supabase-auth.guard';
+import { CsrfGuard } from './guards/csrf.guard';
 import { UsersModule } from '../modules/users/users.module';
 import { ObservabilityModule } from '../observability/observability.module';
 
 @Module({
   imports: [UsersModule, ObservabilityModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthRepository, SupabaseAuthGuard],
+  providers: [AuthService, AuthRepository, SupabaseAuthGuard, CsrfGuard],
   exports: [SupabaseAuthGuard],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -11,23 +11,31 @@ vi.mock('argon2', () => ({
 // Mock Supabase config
 vi.mock('../config/supabase.config', () => ({
   getSupabaseClient: vi.fn(),
+  getSupabaseAdminClient: vi.fn(),
 }));
 
 import { AuthService } from './auth.service';
+import { RefreshTokenRotationConflictError } from './repositories/auth.repository';
 import { getSupabaseClient } from '../config/supabase.config';
 import * as argon2 from 'argon2';
 
 const mockSignUp = vi.fn();
 const mockSignInWithPassword = vi.fn();
+const mockRefreshSession = vi.fn();
 
 const mockUsersRepository = {
   findByEmail: vi.fn(),
   findByUsername: vi.fn(),
+  findBySupabaseId: vi.fn(),
   create: vi.fn(),
 };
 
 const mockAuthRepository = {
   findActiveRefreshToken: vi.fn(),
+  findRefreshTokenByHash: vi.fn(),
+  createRefreshToken: vi.fn(),
+  rotateRefreshToken: vi.fn(),
+  revokeAllActiveUserTokens: vi.fn(),
   revokeRefreshToken: vi.fn(),
 };
 
@@ -51,11 +59,18 @@ beforeEach(() => {
     auth: {
       signUp: mockSignUp,
       signInWithPassword: mockSignInWithPassword,
+      refreshSession: mockRefreshSession,
     },
   } as never);
 
   mockAuthRepository.findActiveRefreshToken.mockResolvedValue(null);
+  mockAuthRepository.findRefreshTokenByHash.mockResolvedValue(null);
+  mockAuthRepository.createRefreshToken.mockResolvedValue(undefined);
+  mockAuthRepository.rotateRefreshToken.mockResolvedValue(undefined);
+  mockAuthRepository.revokeAllActiveUserTokens.mockResolvedValue(undefined);
   mockAuthRepository.revokeRefreshToken.mockResolvedValue(undefined);
+  mockUsersRepository.findBySupabaseId.mockResolvedValue(null);
+  mockRefreshSession.mockReset();
 });
 
 describe('AuthService.register', () => {
@@ -189,6 +204,33 @@ describe('AuthService.login', () => {
     expect(result).toEqual(sessionData);
   });
 
+  it('persists hashed refresh token on successful login when local user exists', async () => {
+    const dto = { email: 'user@example.com', password: 'secret123' };
+    const sessionData = {
+      session: { access_token: 'jwt-token', refresh_token: 'refresh-token' },
+      user: { id: 'supabase-id-1' },
+    };
+
+    mockSignInWithPassword.mockResolvedValue({
+      data: sessionData,
+      error: null,
+    });
+    mockUsersRepository.findBySupabaseId.mockResolvedValue({
+      id: 'local-user-1',
+    });
+
+    const service = buildService();
+    await service.login(dto, { ipAddress: '127.0.0.1', userAgent: 'vitest' });
+
+    expect(mockAuthRepository.createRefreshToken).toHaveBeenCalledOnce();
+    const arg = mockAuthRepository.createRefreshToken.mock.calls[0][0] as {
+      tokenHash: string;
+      userId: string;
+    };
+    expect(arg.userId).toBe('local-user-1');
+    expect(arg.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it('throws when Supabase returns an error', async () => {
     const dto = { email: 'user@example.com', password: 'wrong' };
     mockSignInWithPassword.mockResolvedValue({
@@ -231,7 +273,11 @@ describe('AuthService.logout', () => {
       revokedAt: null,
       expiresAt: new Date(Date.now() + 3600_000),
       createdAt: new Date(),
+      updatedAt: new Date(),
       revocationReason: null,
+      replacedByTokenId: null,
+      ipAddress: null,
+      userAgent: null,
     };
     mockAuthRepository.findActiveRefreshToken.mockResolvedValue(tokenRecord);
     mockAuthRepository.revokeRefreshToken.mockResolvedValue(undefined);
@@ -289,7 +335,11 @@ describe('AuthService.logout', () => {
       revokedAt: null,
       expiresAt: new Date(Date.now() + 3600_000),
       createdAt: new Date(),
+      updatedAt: new Date(),
       revocationReason: null,
+      replacedByTokenId: null,
+      ipAddress: null,
+      userAgent: null,
     };
     mockAuthRepository.findActiveRefreshToken.mockResolvedValue(tokenRecord);
     mockAuthRepository.revokeRefreshToken.mockRejectedValue(
@@ -300,5 +350,82 @@ describe('AuthService.logout', () => {
 
     // Must not throw — DB errors are absorbed.
     await expect(service.logout('some-raw-token')).resolves.toBeUndefined();
+  });
+});
+
+describe('AuthService.refreshSession', () => {
+  it('throws UnauthorizedException when token does not exist', async () => {
+    mockAuthRepository.findRefreshTokenByHash.mockResolvedValue(null);
+    const service = buildService();
+    await expect(
+      service.refreshSession({ rawRefreshToken: 'missing-token' }),
+    ).rejects.toThrow('Unauthorized');
+  });
+
+  it('rotates refresh token and returns new access token when refresh is valid', async () => {
+    mockAuthRepository.findRefreshTokenByHash.mockResolvedValue({
+      id: 'token-id-1',
+      userId: 'user-id-1',
+      tokenHash: 'hash-1',
+      revokedAt: null,
+      revocationReason: null,
+      replacedByTokenId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+      ipAddress: null,
+      userAgent: null,
+    });
+    mockRefreshSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+        },
+      },
+      error: null,
+    });
+
+    const service = buildService();
+    const result = await service.refreshSession({
+      rawRefreshToken: 'valid-raw-refresh',
+    });
+
+    expect(result.accessToken).toBe('new-access-token');
+    expect(result.refreshToken).toBe('new-refresh-token');
+    expect(mockAuthRepository.rotateRefreshToken).toHaveBeenCalledOnce();
+  });
+
+  it('returns Unauthorized when rotation loses the single-use race', async () => {
+    mockAuthRepository.findRefreshTokenByHash.mockResolvedValue({
+      id: 'token-id-1',
+      userId: 'user-id-1',
+      tokenHash: 'hash-1',
+      revokedAt: null,
+      revocationReason: null,
+      replacedByTokenId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+      ipAddress: null,
+      userAgent: null,
+    });
+    mockRefreshSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+        },
+      },
+      error: null,
+    });
+    mockAuthRepository.rotateRefreshToken.mockRejectedValue(
+      new RefreshTokenRotationConflictError(),
+    );
+
+    const service = buildService();
+    await expect(
+      service.refreshSession({ rawRefreshToken: 'valid-raw-refresh' }),
+    ).rejects.toThrow('Unauthorized');
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,9 +5,10 @@ import {
   ConflictException,
   InternalServerErrorException,
   Logger,
+  UnauthorizedException,
 } from '@nestjs/common';
 import * as argon2 from 'argon2';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 
 import { RegisterRequestDto } from './dto/register.request.dto';
 import { LoginDto } from './dto/login.dto';
@@ -18,6 +19,7 @@ import {
 import { UsersRepository } from '../modules/users/repositories/users.repository';
 import {
   AuthRepository,
+  RefreshTokenRotationConflictError,
   type RefreshTokenRecord,
 } from './repositories/auth.repository';
 import { SecurityMonitorService } from '../observability/alerts/security-monitor.service';
@@ -25,6 +27,8 @@ import { SecurityMonitorService } from '../observability/alerts/security-monitor
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
+  private readonly refreshTtlMs =
+    Number(process.env.REFRESH_TOKEN_TTL_DAYS ?? '7') * 24 * 60 * 60 * 1000;
 
   constructor(
     private readonly usersRepository: UsersRepository,
@@ -122,7 +126,10 @@ export class AuthService {
     }
   }
 
-  async login(data: LoginDto) {
+  async login(
+    data: LoginDto,
+    metadata?: { ipAddress?: string; userAgent?: string },
+  ) {
     const supabase = getSupabaseClient();
     const { email, password } = data;
     const { data: signInData, error } = await supabase.auth.signInWithPassword({
@@ -133,7 +140,94 @@ export class AuthService {
       this.securityMonitor.recordFailedLogin();
       throw new Error(error.message);
     }
+
+    const refreshToken = signInData.session?.refresh_token;
+    const supabaseUserId = signInData.user?.id;
+    if (refreshToken && supabaseUserId) {
+      const user = await this.usersRepository.findBySupabaseId(supabaseUserId);
+      if (user) {
+        await this.authRepository.createRefreshToken({
+          userId: user.id,
+          tokenHash: this.hashToken(refreshToken),
+          expiresAt: new Date(Date.now() + this.refreshTtlMs),
+          ipAddress: metadata?.ipAddress,
+          userAgent: metadata?.userAgent,
+        });
+      }
+    }
+
     return signInData;
+  }
+
+  async refreshSession(params: {
+    rawRefreshToken: string;
+    ipAddress?: string;
+    userAgent?: string;
+  }): Promise<{
+    accessToken: string;
+    refreshToken: string;
+    refreshExpiresAt: Date;
+    csrfToken: string;
+  }> {
+    const tokenHash = this.hashToken(params.rawRefreshToken);
+    const existingToken =
+      await this.authRepository.findRefreshTokenByHash(tokenHash);
+
+    if (!existingToken) {
+      this.securityMonitor.recordInvalidToken();
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    if (
+      existingToken.revokedAt ||
+      existingToken.expiresAt.getTime() <= Date.now()
+    ) {
+      await this.authRepository.revokeAllActiveUserTokens(
+        existingToken.userId,
+        'reuse_detected',
+      );
+      this.securityMonitor.recordInvalidToken();
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase.auth.refreshSession({
+      refresh_token: params.rawRefreshToken,
+    });
+
+    if (error || !data.session?.access_token || !data.session.refresh_token) {
+      this.securityMonitor.recordInvalidToken();
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const nextRefreshToken = data.session.refresh_token;
+    const nextRefreshHash = this.hashToken(nextRefreshToken);
+    const nextExpiry = new Date(Date.now() + this.refreshTtlMs);
+
+    try {
+      await this.authRepository.rotateRefreshToken({
+        currentTokenId: existingToken.id,
+        currentTokenHash: tokenHash,
+        newTokenHash: nextRefreshHash,
+        userId: existingToken.userId,
+        newExpiresAt: nextExpiry,
+        ipAddress: params.ipAddress,
+        userAgent: params.userAgent,
+      });
+    } catch (error) {
+      if (error instanceof RefreshTokenRotationConflictError) {
+        this.securityMonitor.recordInvalidToken();
+        throw new UnauthorizedException('Unauthorized');
+      }
+      throw error;
+    }
+
+    return {
+      accessToken: data.session.access_token,
+      refreshToken: nextRefreshToken,
+      refreshExpiresAt: nextExpiry,
+      csrfToken: this.generateCsrfToken(),
+    };
   }
 
   /**
@@ -153,7 +247,7 @@ export class AuthService {
     }
 
     // Hash the raw token before querying; we never store raw tokens.
-    const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+    const tokenHash = this.hashToken(rawToken);
 
     try {
       const token: RefreshTokenRecord | null =
@@ -177,5 +271,13 @@ export class AuthService {
         message: err instanceof Error ? err.message : 'Unknown DB error',
       });
     }
+  }
+
+  private hashToken(rawToken: string): string {
+    return createHash('sha256').update(rawToken).digest('hex');
+  }
+
+  private generateCsrfToken(): string {
+    return randomBytes(32).toString('base64url');
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,7 +11,10 @@ import { createHash } from 'crypto';
 
 import { RegisterRequestDto } from './dto/register.request.dto';
 import { LoginDto } from './dto/login.dto';
-import { getSupabaseClient } from '../config/supabase.config';
+import {
+  getSupabaseClient,
+  getSupabaseAdminClient,
+} from '../config/supabase.config';
 import { UsersRepository } from '../modules/users/repositories/users.repository';
 import {
   AuthRepository,
@@ -80,6 +83,32 @@ export class AuthService {
         createdAt: user.createdAt,
       };
     } catch (err: unknown) {
+      // The Supabase user was already created above. Roll it back so we do not
+      // leave an orphaned Supabase user with no local DB counterpart.
+      if (supabaseUserId) {
+        try {
+          const supabaseAdmin = getSupabaseAdminClient();
+          const { error: deleteError } =
+            await supabaseAdmin.auth.admin.deleteUser(supabaseUserId);
+          if (deleteError) {
+            this.logger.warn({
+              event: 'auth.register.supabase_rollback_failed',
+              supabaseUserId,
+              reason: deleteError.message,
+            });
+          }
+        } catch (rollbackErr: unknown) {
+          this.logger.warn({
+            event: 'auth.register.supabase_rollback_error',
+            supabaseUserId,
+            reason:
+              rollbackErr instanceof Error
+                ? rollbackErr.message
+                : 'Unknown error',
+          });
+        }
+      }
+
       // Map Prisma unique constraint violation to ConflictException
       if (
         typeof err === 'object' &&

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -5,10 +5,10 @@ import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 export class LoginDto {
   @IsEmail()
   @IsNotEmpty({ message: 'El email es requerido' })
-  email: string;
+  email!: string;
 
   @IsString({ message: 'La contraseña debe ser texto' })
   @IsNotEmpty({ message: 'La contraseña es requerida' })
   @MinLength(6, { message: 'La contraseña debe tener al menos 6 caracteres' })
-  password: string;
+  password!: string;
 }

--- a/src/auth/dto/register.request.dto.ts
+++ b/src/auth/dto/register.request.dto.ts
@@ -9,7 +9,7 @@ export class RegisterRequestDto {
   })
   @IsEmail()
   @IsNotEmpty({ message: 'Campo email no debe ir vacío' })
-  email: string;
+  email!: string;
 
   @ApiProperty({
     description: 'Unique username (no spaces allowed)',
@@ -17,7 +17,7 @@ export class RegisterRequestDto {
   })
   @IsNotEmpty({ message: 'Nombre de usuario no debe ir vacío' })
   @NoSpaces({ always: true, message: 'No debe tener espacio(s)' })
-  username: string;
+  username!: string;
 
   @ApiProperty({
     description:
@@ -31,5 +31,5 @@ export class RegisterRequestDto {
     minNumbers: 1,
     minSymbols: 1,
   })
-  password: string;
+  password!: string;
 }

--- a/src/auth/dto/register.response.dto.ts
+++ b/src/auth/dto/register.response.dto.ts
@@ -5,25 +5,25 @@ export class RegisterUserDataDto {
     description: 'Unique identifier of the created user (UUID)',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  id: string;
+  id!: string;
 
   @ApiProperty({
     description: 'Email address of the created user',
     example: 'user@example.com',
   })
-  email: string;
+  email!: string;
 
   @ApiProperty({
     description: 'Username of the created user',
     example: 'testuser',
   })
-  username: string;
+  username!: string;
 
   @ApiProperty({
     description: 'Timestamp when the user was created',
     example: '2026-01-01T00:00:00.000Z',
   })
-  createdAt: Date;
+  createdAt!: Date;
 }
 
 export class RegisterResponseDto {
@@ -31,17 +31,17 @@ export class RegisterResponseDto {
     description: 'Indicates whether the operation succeeded',
     example: true,
   })
-  success: boolean;
+  success!: boolean;
 
   @ApiProperty({
     description: 'Created user data (public fields only)',
     type: RegisterUserDataDto,
   })
-  data: RegisterUserDataDto;
+  data!: RegisterUserDataDto;
 
   @ApiProperty({
     description: 'Human-readable result message',
     example: 'User registered successfully',
   })
-  message: string;
+  message!: string;
 }

--- a/src/auth/guards/csrf.guard.spec.ts
+++ b/src/auth/guards/csrf.guard.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { CsrfGuard } from './csrf.guard';
+
+function buildContext(input: {
+  header?: string;
+  cookie?: string;
+}): ExecutionContext {
+  const req = {
+    headers: input.header ? { 'x-csrf-token': input.header } : {},
+    cookies: input.cookie ? { 'XSRF-TOKEN': input.cookie } : {},
+  };
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('CsrfGuard', () => {
+  const guard = new CsrfGuard();
+
+  it('allows request when header and cookie match', () => {
+    const ctx = buildContext({ header: 'abc', cookie: 'abc' });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('rejects request when header is missing', () => {
+    const ctx = buildContext({ cookie: 'abc' });
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('rejects request when cookie is missing', () => {
+    const ctx = buildContext({ header: 'abc' });
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('rejects request when header and cookie differ', () => {
+    const ctx = buildContext({ header: 'abc', cookie: 'xyz' });
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+});

--- a/src/auth/guards/csrf.guard.ts
+++ b/src/auth/guards/csrf.guard.ts
@@ -1,0 +1,28 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { XSRF_TOKEN_COOKIE } from '../../common/utils/cookies';
+
+@Injectable()
+export class CsrfGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+
+    const csrfHeader = req.headers['x-csrf-token'];
+    const csrfCookie = req.cookies?.[XSRF_TOKEN_COOKIE] as string | undefined;
+
+    const headerToken =
+      typeof csrfHeader === 'string' ? csrfHeader.trim() : undefined;
+    const cookieToken = csrfCookie?.trim();
+
+    if (!headerToken || !cookieToken || headerToken !== cookieToken) {
+      throw new ForbiddenException('Forbidden');
+    }
+
+    return true;
+  }
+}

--- a/src/auth/repositories/auth.repository.spec.ts
+++ b/src/auth/repositories/auth.repository.spec.ts
@@ -1,15 +1,24 @@
 // src/auth/repositories/auth.repository.spec.ts
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { AuthRepository, type RefreshTokenRecord } from './auth.repository';
+import {
+  AuthRepository,
+  RefreshTokenRotationConflictError,
+  type RefreshTokenRecord,
+} from './auth.repository';
 
 const mockPrismaRefreshToken = {
   findFirst: vi.fn(),
+  findUnique: vi.fn(),
+  create: vi.fn(),
   updateMany: vi.fn(),
 };
 
 const mockPrismaService = {
   refreshToken: mockPrismaRefreshToken,
+  $transaction: vi.fn((cb: (tx: typeof mockPrismaService) => unknown) =>
+    cb(mockPrismaService),
+  ),
 };
 
 describe('AuthRepository', () => {
@@ -56,7 +65,11 @@ describe('AuthRepository', () => {
         revokedAt: null,
         expiresAt: new Date(Date.now() + 3600_000),
         createdAt: new Date(),
+        updatedAt: new Date(),
         revocationReason: null,
+        replacedByTokenId: null,
+        ipAddress: null,
+        userAgent: null,
       };
       mockPrismaRefreshToken.findFirst.mockResolvedValue(tokenRecord);
 
@@ -120,6 +133,54 @@ describe('AuthRepository', () => {
       await expect(
         repository.revokeRefreshToken('nonexistent-hash'),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('findRefreshTokenByHash', () => {
+    it('queries prisma.findUnique by token hash', async () => {
+      mockPrismaRefreshToken.findUnique.mockResolvedValue(null);
+      await repository.findRefreshTokenByHash('hash-x');
+      expect(mockPrismaRefreshToken.findUnique).toHaveBeenCalledWith({
+        where: { tokenHash: 'hash-x' },
+      });
+    });
+  });
+
+  describe('createRefreshToken', () => {
+    it('creates a token with hash and expiration', async () => {
+      mockPrismaRefreshToken.create.mockResolvedValue({ id: 'token-1' });
+      const expiresAt = new Date(Date.now() + 60_000);
+      await repository.createRefreshToken({
+        userId: 'user-1',
+        tokenHash: 'hash-1',
+        expiresAt,
+      });
+      expect(mockPrismaRefreshToken.create).toHaveBeenCalledWith({
+        data: {
+          userId: 'user-1',
+          tokenHash: 'hash-1',
+          expiresAt,
+          ipAddress: undefined,
+          userAgent: undefined,
+        },
+      });
+    });
+  });
+
+  describe('rotateRefreshToken', () => {
+    it('throws when the old token was already revoked by a concurrent request', async () => {
+      mockPrismaRefreshToken.create.mockResolvedValue({ id: 'new-token-id' });
+      mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        repository.rotateRefreshToken({
+          currentTokenId: 'old-token-id',
+          currentTokenHash: 'old-hash',
+          newTokenHash: 'new-hash',
+          userId: 'user-1',
+          newExpiresAt: new Date(Date.now() + 60_000),
+        }),
+      ).rejects.toBeInstanceOf(RefreshTokenRotationConflictError);
     });
   });
 });

--- a/src/auth/repositories/auth.repository.ts
+++ b/src/auth/repositories/auth.repository.ts
@@ -15,8 +15,18 @@ export interface RefreshTokenRecord {
   tokenHash: string;
   revokedAt: Date | null;
   revocationReason: string | null;
+  replacedByTokenId: string | null;
   createdAt: Date;
+  updatedAt: Date;
   expiresAt: Date;
+  ipAddress: string | null;
+  userAgent: string | null;
+}
+
+export class RefreshTokenRotationConflictError extends Error {
+  constructor() {
+    super('Refresh token rotation conflict');
+  }
 }
 
 @Injectable()
@@ -41,6 +51,77 @@ export class AuthRepository {
     }) as Promise<RefreshTokenRecord | null>;
   }
 
+  findRefreshTokenByHash(
+    tokenHash: string,
+  ): Promise<RefreshTokenRecord | null> {
+    const client = this.prisma as unknown as PrismaClient;
+    return client.refreshToken.findUnique({
+      where: { tokenHash },
+    }) as Promise<RefreshTokenRecord | null>;
+  }
+
+  createRefreshToken(data: {
+    userId: string;
+    tokenHash: string;
+    expiresAt: Date;
+    ipAddress?: string;
+    userAgent?: string;
+  }): Promise<RefreshTokenRecord> {
+    const client = this.prisma as unknown as PrismaClient;
+    return client.refreshToken.create({
+      data: {
+        userId: data.userId,
+        tokenHash: data.tokenHash,
+        expiresAt: data.expiresAt,
+        ipAddress: data.ipAddress,
+        userAgent: data.userAgent,
+      },
+    }) as Promise<RefreshTokenRecord>;
+  }
+
+  async rotateRefreshToken(params: {
+    currentTokenId: string;
+    currentTokenHash: string;
+    newTokenHash: string;
+    userId: string;
+    newExpiresAt: Date;
+    ipAddress?: string;
+    userAgent?: string;
+  }): Promise<RefreshTokenRecord> {
+    const client = this.prisma as unknown as PrismaClient;
+
+    return client.$transaction(async (tx) => {
+      const newToken = (await tx.refreshToken.create({
+        data: {
+          userId: params.userId,
+          tokenHash: params.newTokenHash,
+          expiresAt: params.newExpiresAt,
+          ipAddress: params.ipAddress,
+          userAgent: params.userAgent,
+        },
+      })) as RefreshTokenRecord;
+
+      const updateResult = await tx.refreshToken.updateMany({
+        where: {
+          id: params.currentTokenId,
+          tokenHash: params.currentTokenHash,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: new Date(),
+          revocationReason: 'rotation',
+          replacedByTokenId: newToken.id,
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        throw new RefreshTokenRotationConflictError();
+      }
+
+      return newToken;
+    });
+  }
+
   /**
    * Marks a refresh token as revoked by setting `revokedAt` to the current
    * timestamp and recording the reason.
@@ -53,6 +134,23 @@ export class AuthRepository {
     await client.refreshToken.updateMany({
       where: {
         tokenHash,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+        revocationReason: reason,
+      },
+    });
+  }
+
+  async revokeAllActiveUserTokens(
+    userId: string,
+    reason: string,
+  ): Promise<void> {
+    const client = this.prisma as unknown as PrismaClient;
+    await client.refreshToken.updateMany({
+      where: {
+        userId,
         revokedAt: null,
       },
       data: {

--- a/src/common/utils/cookies.spec.ts
+++ b/src/common/utils/cookies.spec.ts
@@ -66,7 +66,7 @@ describe('clearAuthCookies', () => {
     expect(options.httpOnly).toBe(false);
   });
 
-  it('uses path "/" for both cookies', () => {
+  it('uses restricted path for refresh cookie and root path for XSRF cookie', () => {
     const res = buildMockRes();
 
     clearAuthCookies(res);
@@ -76,9 +76,10 @@ describe('clearAuthCookies', () => {
       Record<string, unknown>,
     ][];
 
-    for (const [, options] of calls) {
-      expect(options.path).toBe('/');
-    }
+    const refreshCall = calls.find(([name]) => name === REFRESH_TOKEN_COOKIE);
+    const xsrfCall = calls.find(([name]) => name === XSRF_TOKEN_COOKIE);
+    expect(refreshCall?.[1].path).toBe('/api/v1/auth');
+    expect(xsrfCall?.[1].path).toBe('/');
   });
 
   it('does not set domain in development', () => {

--- a/src/common/utils/cookies.ts
+++ b/src/common/utils/cookies.ts
@@ -5,7 +5,7 @@
 // clearing them from the server is predictable regardless of the exact path
 // from which the request was issued.
 
-import type { Response } from 'express';
+import type { CookieOptions, Response } from 'express';
 
 /** Name of the httpOnly refresh-token cookie. */
 export const REFRESH_TOKEN_COOKIE = 'refresh_token';
@@ -15,6 +15,37 @@ export const XSRF_TOKEN_COOKIE = 'XSRF-TOKEN';
 
 /** Shared cookie path. */
 const COOKIE_PATH = '/';
+const REFRESH_COOKIE_PATH = '/api/v1/auth';
+
+export function buildRefreshTokenCookieOptions(expiresAt: Date): CookieOptions {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const cookieDomain = isProduction ? '.tribehub.io' : undefined;
+
+  return {
+    httpOnly: true,
+    secure: !isDevelopment,
+    sameSite: 'strict',
+    domain: cookieDomain,
+    path: REFRESH_COOKIE_PATH,
+    expires: expiresAt,
+  };
+}
+
+export function buildCsrfCookieOptions(expiresAt: Date): CookieOptions {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const cookieDomain = isProduction ? '.tribehub.io' : undefined;
+
+  return {
+    httpOnly: false,
+    secure: !isDevelopment,
+    sameSite: 'strict',
+    domain: cookieDomain,
+    path: COOKIE_PATH,
+    expires: expiresAt,
+  };
+}
 
 /**
  * Clears both the `refresh_token` and `XSRF-TOKEN` cookies from the response.
@@ -26,23 +57,15 @@ const COOKIE_PATH = '/';
  * flag are applied regardless of when the module was first loaded.
  */
 export function clearAuthCookies(res: Response): void {
-  const isProduction = process.env.NODE_ENV === 'production';
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  const cookieDomain = isProduction ? '.tribehub.io' : undefined;
-
   res.clearCookie(REFRESH_TOKEN_COOKIE, {
-    httpOnly: true,
-    secure: !isDevelopment,
-    sameSite: 'strict',
-    domain: cookieDomain,
-    path: COOKIE_PATH,
+    ...buildRefreshTokenCookieOptions(new Date(0)),
+    expires: undefined,
+    maxAge: 0,
   });
 
   res.clearCookie(XSRF_TOKEN_COOKIE, {
-    httpOnly: false, // XSRF-TOKEN must be readable by JavaScript
-    secure: !isDevelopment,
-    sameSite: 'strict',
-    domain: cookieDomain,
-    path: COOKIE_PATH,
+    ...buildCsrfCookieOptions(new Date(0)),
+    expires: undefined,
+    maxAge: 0,
   });
 }

--- a/src/config/supabase.config.ts
+++ b/src/config/supabase.config.ts
@@ -20,6 +20,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 let instance: SupabaseClient | null = null;
+let adminInstance: SupabaseClient | null = null;
 
 export function getSupabaseClient(): SupabaseClient {
   if (instance) {
@@ -47,9 +48,48 @@ export function getSupabaseClient(): SupabaseClient {
 }
 
 /**
- * Resets the singleton. Intended for use in unit tests only — production code
+ * Returns a Supabase client initialised with the service-role key.
+ * This client bypasses Row Level Security and has admin privileges —
+ * use only for server-side operations that require elevated access
+ * (e.g. auth.admin.deleteUser during registration rollback).
+ *
+ * Never expose this client or its key to untrusted callers.
+ */
+export function getSupabaseAdminClient(): SupabaseClient {
+  if (adminInstance) {
+    return adminInstance;
+  }
+
+  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!SUPABASE_URL) {
+    throw new Error('Missing required environment variable: SUPABASE_URL');
+  }
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      'Missing required environment variable: SUPABASE_SERVICE_ROLE_KEY',
+    );
+  }
+
+  adminInstance = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      // Disable automatic session persistence — the admin client is used for
+      // one-off server-side operations and must never store session state.
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    realtime: { params: { eventsPerSecond: -1 } },
+  });
+
+  return adminInstance;
+}
+
+/**
+ * Resets the singletons. Intended for use in unit tests only — production code
  * must never call this function.
  */
 export function _resetSupabaseClientForTesting(): void {
   instance = null;
+  adminInstance = null;
 }

--- a/src/config/supabase.config.ts
+++ b/src/config/supabase.config.ts
@@ -36,12 +36,6 @@ export function getSupabaseClient(): SupabaseClient {
     throw new Error('Missing required environment variable: SUPABASE_ANON_KEY');
   }
 
-  console.log('[DEBUG] SUPABASE_URL:', SUPABASE_URL);
-  console.log(
-    '[DEBUG] SUPABASE_ANON_KEY prefix:',
-    SUPABASE_ANON_KEY.slice(0, 20) + '...',
-  );
-
   instance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     // Disable the Realtime subscription manager entirely — the backend never
     // subscribes to database changes via this client, and the underlying

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './instrument';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, BadRequestException } from '@nestjs/common';
 import { ValidationError } from 'class-validator';
-import * as cookieParser from 'cookie-parser';
+import cookieParser from 'cookie-parser';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { Request, Response, NextFunction } from 'express';
 import { verify } from 'jsonwebtoken';

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,7 @@ async function bootstrap() {
     allowedHeaders: [
       'Content-Type',
       'Authorization',
+      'X-CSRF-Token',
       'X-Requested-With',
       'Accept',
       'Origin',

--- a/src/modules/users/dto/update-user.dto.ts
+++ b/src/modules/users/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-// src/auth/dto/update-user.dto.ts
+// src/modules/users/dto/update-user.dto.ts
 
 import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
 

--- a/src/modules/users/repositories/users.repository.spec.ts
+++ b/src/modules/users/repositories/users.repository.spec.ts
@@ -145,4 +145,19 @@ describe('UsersRepository', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('findBySupabaseId', () => {
+    it('calls prisma.user.findFirst filtering by supabaseId and deletedAt: null', async () => {
+      mockPrismaUser.findFirst.mockResolvedValue(null);
+
+      await repository.findBySupabaseId('supabase-123');
+
+      expect(mockPrismaUser.findFirst).toHaveBeenCalledWith({
+        where: {
+          supabaseId: 'supabase-123',
+          deletedAt: null,
+        },
+      });
+    });
+  });
 });

--- a/src/modules/users/repositories/users.repository.ts
+++ b/src/modules/users/repositories/users.repository.ts
@@ -43,4 +43,13 @@ export class UsersRepository {
       },
     });
   }
+
+  async findBySupabaseId(supabaseId: string): Promise<User | null> {
+    return this.prisma.user.findFirst({
+      where: {
+        supabaseId,
+        deletedAt: null,
+      },
+    });
+  }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -5,12 +5,13 @@ import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 import { PrismaService } from './../src/prisma/prisma.service';
+import { QueueService } from './../src/queues/queue.service';
+import { DefaultWorker } from './../src/queues/workers/default.worker';
+import { QueueMonitorService } from './../src/queues/alerts/queue-monitor.service';
 
-// Set required env vars before any module is imported/initialized.
-// getRedisConnection() throws at module load time when REDIS_URL is absent.
-// Pointing to localhost is sufficient for the module to boot; a live Redis
-// connection is not required for the health/root endpoint test.
-process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+// Keep Redis disabled in e2e. Queue providers are mocked below, and optional
+// Redis-backed services should fall back without opening sockets.
+delete process.env.REDIS_URL;
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -23,6 +24,29 @@ describe('AppController (e2e)', () => {
       .useValue({
         $connect: vi.fn(),
         $disconnect: vi.fn(),
+      })
+      .overrideProvider(QueueService)
+      .useValue({
+        queue: {
+          name: 'jobs',
+          metaValues: { version: 'bullmq:5.0.0' },
+        },
+        enqueueSendWelcomeEmail: vi.fn(),
+        enqueueProcessImage: vi.fn(),
+        getWaitingCount: vi.fn().mockResolvedValue(0),
+        getFailedCount: vi.fn().mockResolvedValue(0),
+        onModuleDestroy: vi.fn(),
+      })
+      .overrideProvider(DefaultWorker)
+      .useValue({
+        onModuleInit: vi.fn(),
+        onModuleDestroy: vi.fn(),
+      })
+      .overrideProvider(QueueMonitorService)
+      .useValue({
+        onModuleInit: vi.fn(),
+        onModuleDestroy: vi.fn(),
+        runCheck: vi.fn(),
       })
       .compile();
 

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -74,9 +74,11 @@ function applyGlobalSetup(app: INestApplication): void {
 describe('POST /api/v1/auth/register (e2e)', () => {
   let app: INestApplication<App>;
   let mockRegister: ReturnType<typeof vi.fn>;
+  let mockRefreshSession: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     mockRegister = vi.fn();
+    mockRefreshSession = vi.fn();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -91,6 +93,7 @@ describe('POST /api/v1/auth/register (e2e)', () => {
         register: mockRegister,
         login: vi.fn(),
         logout: vi.fn(),
+        refreshSession: mockRefreshSession,
       })
       .compile();
 
@@ -297,6 +300,33 @@ describe('POST /api/v1/auth/register (e2e)', () => {
     expect(response.body).toMatchObject({
       statusCode: 500,
       message: 'Failed to create user',
+    });
+  });
+
+  it('returns 403 on /auth/refresh when CSRF header is missing', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/auth/refresh')
+      .set('Cookie', ['refresh_token=token-a', 'XSRF-TOKEN=csrf-a'])
+      .expect(403);
+  });
+
+  it('returns 200 on /auth/refresh with valid csrf + cookies', async () => {
+    mockRefreshSession.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      refreshExpiresAt: new Date(Date.now() + 60_000),
+      csrfToken: 'new-csrf-token',
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/refresh')
+      .set('X-CSRF-Token', 'csrf-a')
+      .set('Cookie', ['refresh_token=token-a', 'XSRF-TOKEN=csrf-a'])
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      success: true,
+      data: { accessToken: 'new-access-token' },
     });
   });
 });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,302 @@
+import { vi } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  BadRequestException,
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ValidationError } from 'class-validator';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import cookieParser from 'cookie-parser';
+import { AppModule } from './../src/app.module';
+import { PrismaService } from './../src/prisma/prisma.service';
+import { AuthService } from './../src/auth/auth.service';
+
+// Ensure Redis URL is present so modules that read it at load time do not throw.
+process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+const VALID_PAYLOAD = {
+  email: 'alice@example.com',
+  username: 'alice',
+  password: 'Secure@123',
+};
+
+const REGISTERED_USER = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  email: VALID_PAYLOAD.email,
+  username: VALID_PAYLOAD.username,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — replicate the bootstrap() setup from main.ts
+// ---------------------------------------------------------------------------
+
+function applyGlobalSetup(app: INestApplication): void {
+  app.use(cookieParser());
+  app.setGlobalPrefix('api/v1');
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      stopAtFirstError: true,
+      exceptionFactory: (errors: ValidationError[]) => {
+        const messages = errors.map((error) => {
+          const constraintsMap: Record<string, string> = (error.constraints ??
+            {}) as Record<string, string>;
+          const constraints: string[] = Object.values(constraintsMap);
+          return {
+            field: error.property,
+            errors: constraints,
+          };
+        });
+        return new BadRequestException({
+          message: 'Errores de validación',
+          errors: messages,
+        });
+      },
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/auth/register (e2e)', () => {
+  let app: INestApplication<App>;
+  let mockRegister: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    mockRegister = vi.fn();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: vi.fn(),
+        $disconnect: vi.fn(),
+      })
+      .overrideProvider(AuthService)
+      .useValue({
+        register: mockRegister,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    applyGlobalSetup(app);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path — 201 Created
+  // -------------------------------------------------------------------------
+
+  it('returns 201 and the created user data on a valid registration', async () => {
+    mockRegister.mockResolvedValue(REGISTERED_USER);
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(VALID_PAYLOAD)
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      success: true,
+      message: 'User registered successfully',
+      data: {
+        id: REGISTERED_USER.id,
+        email: REGISTERED_USER.email,
+        username: REGISTERED_USER.username,
+      },
+    });
+
+    // passwordHash must never appear in the response
+    expect(JSON.stringify(response.body)).not.toContain('passwordHash');
+    expect(JSON.stringify(response.body)).not.toContain('password');
+
+    expect(mockRegister).toHaveBeenCalledOnce();
+    expect(mockRegister).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: VALID_PAYLOAD.email,
+        username: VALID_PAYLOAD.username,
+        password: VALID_PAYLOAD.password,
+      }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 409 Conflict — duplicate email
+  // -------------------------------------------------------------------------
+
+  it('returns 409 when the email is already in use', async () => {
+    mockRegister.mockRejectedValue(
+      new ConflictException('Email already in use'),
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(VALID_PAYLOAD)
+      .expect(409);
+
+    expect(response.body).toMatchObject({
+      statusCode: 409,
+      message: 'Email already in use',
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 409 Conflict — duplicate username
+  // -------------------------------------------------------------------------
+
+  it('returns 409 when the username is already in use', async () => {
+    mockRegister.mockRejectedValue(
+      new ConflictException('Username already in use'),
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(VALID_PAYLOAD)
+      .expect(409);
+
+    expect(response.body).toMatchObject({
+      statusCode: 409,
+      message: 'Username already in use',
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 400 Bad Request — missing required fields
+  // -------------------------------------------------------------------------
+
+  it('returns 400 when all required fields are missing', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({})
+      .expect(400);
+
+    expect(response.body.statusCode).toBe(400);
+    // ValidationPipe exceptionFactory wraps errors under the `errors` array
+    expect(response.body).toHaveProperty('errors');
+    expect(Array.isArray(response.body.errors)).toBe(true);
+    expect(response.body.errors.length).toBeGreaterThan(0);
+
+    // Service must NOT have been called when validation fails
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when email is invalid', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({ ...VALID_PAYLOAD, email: 'not-an-email' })
+      .expect(400);
+
+    expect(response.body.statusCode).toBe(400);
+    expect(response.body).toHaveProperty('errors');
+    const emailErrors = (
+      response.body.errors as Array<{ field: string; errors: string[] }>
+    ).find((e) => e.field === 'email');
+    expect(emailErrors).toBeDefined();
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when password does not meet strength requirements', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({ ...VALID_PAYLOAD, password: 'weak' })
+      .expect(400);
+
+    expect(response.body.statusCode).toBe(400);
+    expect(response.body).toHaveProperty('errors');
+    const passwordErrors = (
+      response.body.errors as Array<{ field: string; errors: string[] }>
+    ).find((e) => e.field === 'password');
+    expect(passwordErrors).toBeDefined();
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when username contains spaces', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({ ...VALID_PAYLOAD, username: 'user name' })
+      .expect(400);
+
+    expect(response.body.statusCode).toBe(400);
+    expect(response.body).toHaveProperty('errors');
+    const usernameErrors = (
+      response.body.errors as Array<{ field: string; errors: string[] }>
+    ).find((e) => e.field === 'username');
+    expect(usernameErrors).toBeDefined();
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 400 Bad Request — non-whitelisted extra fields
+  // -------------------------------------------------------------------------
+
+  it('returns 400 when extra unknown fields are sent (forbidNonWhitelisted)', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send({ ...VALID_PAYLOAD, role: 'admin' })
+      .expect(400);
+
+    expect(response.body.statusCode).toBe(400);
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Service-level error wrapping — unexpected errors become 400
+  // -------------------------------------------------------------------------
+
+  it('returns 400 with REGISTER_ERROR code when AuthService throws an unexpected error', async () => {
+    mockRegister.mockRejectedValue(new Error('Supabase is down'));
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(VALID_PAYLOAD)
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      statusCode: 400,
+      message: expect.objectContaining({ code: 'REGISTER_ERROR' }),
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // InternalServerError from service propagates as-is (HttpException passthrough)
+  // -------------------------------------------------------------------------
+
+  it('propagates 500 InternalServerErrorException from AuthService unchanged', async () => {
+    mockRegister.mockRejectedValue(
+      new InternalServerErrorException('Failed to create user'),
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(VALID_PAYLOAD)
+      .expect(500);
+
+    expect(response.body).toMatchObject({
+      statusCode: 500,
+      message: 'Failed to create user',
+    });
+  });
+});

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -14,9 +14,13 @@ import cookieParser from 'cookie-parser';
 import { AppModule } from './../src/app.module';
 import { PrismaService } from './../src/prisma/prisma.service';
 import { AuthService } from './../src/auth/auth.service';
+import { QueueService } from './../src/queues/queue.service';
+import { DefaultWorker } from './../src/queues/workers/default.worker';
+import { QueueMonitorService } from './../src/queues/alerts/queue-monitor.service';
 
-// Ensure Redis URL is present so modules that read it at load time do not throw.
-process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+// Keep Redis disabled in e2e. Queue providers are mocked below, and services
+// that use Redis as an optional cache should fall back without opening sockets.
+delete process.env.REDIS_URL;
 
 // ---------------------------------------------------------------------------
 // Shared mock data
@@ -94,6 +98,29 @@ describe('POST /api/v1/auth/register (e2e)', () => {
         login: vi.fn(),
         logout: vi.fn(),
         refreshSession: mockRefreshSession,
+      })
+      .overrideProvider(QueueService)
+      .useValue({
+        queue: {
+          name: 'jobs',
+          metaValues: { version: 'bullmq:5.0.0' },
+        },
+        enqueueSendWelcomeEmail: vi.fn(),
+        enqueueProcessImage: vi.fn(),
+        getWaitingCount: vi.fn().mockResolvedValue(0),
+        getFailedCount: vi.fn().mockResolvedValue(0),
+        onModuleDestroy: vi.fn(),
+      })
+      .overrideProvider(DefaultWorker)
+      .useValue({
+        onModuleInit: vi.fn(),
+        onModuleDestroy: vi.fn(),
+      })
+      .overrideProvider(QueueMonitorService)
+      .useValue({
+        onModuleInit: vi.fn(),
+        onModuleDestroy: vi.fn(),
+        runCheck: vi.fn(),
       })
       .compile();
 
@@ -192,7 +219,6 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send({})
       .expect(400);
 
-    expect(response.body.statusCode).toBe(400);
     // ValidationPipe exceptionFactory wraps errors under the `errors` array
     expect(response.body).toHaveProperty('errors');
     expect(Array.isArray(response.body.errors)).toBe(true);
@@ -208,7 +234,6 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send({ ...VALID_PAYLOAD, email: 'not-an-email' })
       .expect(400);
 
-    expect(response.body.statusCode).toBe(400);
     expect(response.body).toHaveProperty('errors');
     const emailErrors = (
       response.body.errors as Array<{ field: string; errors: string[] }>
@@ -224,7 +249,6 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send({ ...VALID_PAYLOAD, password: 'weak' })
       .expect(400);
 
-    expect(response.body.statusCode).toBe(400);
     expect(response.body).toHaveProperty('errors');
     const passwordErrors = (
       response.body.errors as Array<{ field: string; errors: string[] }>
@@ -240,7 +264,6 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send({ ...VALID_PAYLOAD, username: 'user name' })
       .expect(400);
 
-    expect(response.body.statusCode).toBe(400);
     expect(response.body).toHaveProperty('errors');
     const usernameErrors = (
       response.body.errors as Array<{ field: string; errors: string[] }>
@@ -260,7 +283,7 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send({ ...VALID_PAYLOAD, role: 'admin' })
       .expect(400);
 
-    expect(response.body.statusCode).toBe(400);
+    expect(response.body).toHaveProperty('message');
 
     expect(mockRegister).not.toHaveBeenCalled();
   });
@@ -278,8 +301,8 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .expect(400);
 
     expect(response.body).toMatchObject({
-      statusCode: 400,
-      message: expect.objectContaining({ code: 'REGISTER_ERROR' }),
+      code: 'REGISTER_ERROR',
+      message: 'Supabase is down',
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
## ¿Qué se hizo?

Se implementó el flujo seguro de refresh token con rotación obligatoria y protección CSRF para las sesiones de autenticación.

Ahora el backend permite renovar la sesión sin exponer el refresh token al frontend, usando cookie HttpOnly y validación CSRF.

## Cambios principales

- Se agregó el endpoint `POST /auth/refresh`.
- Se implementó rotación de refresh token en cada refresh exitoso.
- El refresh token anterior queda revocado después de usarse.
- Se guarda solo el hash del refresh token en base de datos, nunca el token plano.
- Se agregó detección de reutilización/replay de refresh tokens.
- Se agregó protección CSRF usando cookie `XSRF-TOKEN` y header `X-CSRF-Token`.
- Se actualizó logout para limpiar cookies y revocar el refresh token actual.
- Se extendió el modelo `RefreshToken` con datos de rotación y auditoría.
- Se actualizó OpenAPI con el nuevo contrato de cookies y CSRF.
- Se agregaron pruebas unitarias para auth, CSRF, cookies, repositorio y rotación.

## Flujo esperado

1. El usuario inicia sesión.
2. El backend devuelve el access token y guarda el refresh token en cookie HttpOnly.
3. El backend también emite un token CSRF.
4. Cuando el access token expira, el cliente llama a `/auth/refresh`.
5. El backend valida CSRF, valida el refresh token, lo revoca y emite uno nuevo.
6. Si alguien intenta reutilizar un refresh token viejo, la petición falla con `401`.

## Validación

- Tests unitarios pasando: `209 tests`
- Build pasando
- OpenAPI lint pasando
- ESLint sin errores, solo warnings existentes del proyecto

## Nota

No se implementó cliente frontend porque todavía no existe el repo/código Next.js. El backend ya queda listo para integrarse con `credentials: include` y el header `X-CSRF-Token`.
