### PR TITLE
feat: (#83) implementar InterestsModule con catálogo y endpoints de usuario

### DIFF
--- a/prisma/migrations/20250513000000_add_interest_category_status/migration.sql
+++ b/prisma/migrations/20250513000000_add_interest_category_status/migration.sql
@@ -1,0 +1,10 @@
+-- CreateEnum
+CREATE TYPE "InterestStatus" AS ENUM ('VALIDATED', 'PENDING');
+
+-- AlterTable
+ALTER TABLE "interests"
+  ADD COLUMN "category" TEXT,
+  ADD COLUMN "status" "InterestStatus" NOT NULL DEFAULT 'PENDING';
+
+-- CreateIndex
+CREATE INDEX "interests_status_idx" ON "interests"("status");

--- a/prisma/migrations/20260514000000_add_interest_status_inactive/migration.sql
+++ b/prisma/migrations/20260514000000_add_interest_status_inactive/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum: add INACTIVE value to InterestStatus
+ALTER TYPE "InterestStatus" ADD VALUE 'INACTIVE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,11 +92,7 @@ model Interest {
   name      String         @unique
   slug      String         @unique
   category  String?
-<<<<<<< HEAD
   status    InterestStatus @default(PENDING)
-=======
-  status    InterestStatus @default(ACTIVE)
->>>>>>> origin/develop
   createdAt DateTime       @default(now())
 
   // Relaciones

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,11 +91,14 @@ model Interest {
   id        String         @id @default(uuid())
   name      String         @unique
   slug      String         @unique
+  category  String?
+  status    InterestStatus @default(PENDING)
   createdAt DateTime       @default(now())
 
   // Relaciones
   users     UserInterest[]
 
+  @@index([status])
   @@map("interests")
 }
 
@@ -226,4 +229,9 @@ enum ReactionType {
   WOW
   SAD
   ANGRY
+}
+
+enum InterestStatus {
+  VALIDATED
+  PENDING
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,4 +234,5 @@ enum ReactionType {
 enum InterestStatus {
   VALIDATED
   PENDING
+  INACTIVE
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,6 @@
 // prisma/seed.ts
 //
-// Development seed data for system_configs (feature flags).
+// Development seed data for system_configs (feature flags) and interests catalog.
 //
 // Run with:
 //   npx prisma db seed
@@ -53,6 +53,58 @@ async function main(): Promise<void> {
       create: { key: flag.key, value: flag.value, valueType: flag.valueType },
     });
     console.log(`Seeded: ${flag.key} = ${JSON.stringify(flag.value)}`);
+  }
+
+  const interests = [
+    { name: 'Technology', slug: 'technology', category: 'Tech' },
+    { name: 'Programming', slug: 'programming', category: 'Tech' },
+    { name: 'Web Development', slug: 'web-development', category: 'Tech' },
+    { name: 'Mobile Development', slug: 'mobile-development', category: 'Tech' },
+    { name: 'Artificial Intelligence', slug: 'artificial-intelligence', category: 'Tech' },
+    { name: 'Data Science', slug: 'data-science', category: 'Tech' },
+    { name: 'Cybersecurity', slug: 'cybersecurity', category: 'Tech' },
+    { name: 'Open Source', slug: 'open-source', category: 'Tech' },
+    { name: 'Music', slug: 'music', category: 'Arts' },
+    { name: 'Photography', slug: 'photography', category: 'Arts' },
+    { name: 'Film & Cinema', slug: 'film-cinema', category: 'Arts' },
+    { name: 'Visual Arts', slug: 'visual-arts', category: 'Arts' },
+    { name: 'Writing', slug: 'writing', category: 'Arts' },
+    { name: 'Design', slug: 'design', category: 'Arts' },
+    { name: 'Gaming', slug: 'gaming', category: 'Entertainment' },
+    { name: 'Esports', slug: 'esports', category: 'Entertainment' },
+    { name: 'Podcasts', slug: 'podcasts', category: 'Entertainment' },
+    { name: 'Comedy', slug: 'comedy', category: 'Entertainment' },
+    { name: 'Fitness', slug: 'fitness', category: 'Health' },
+    { name: 'Mental Health', slug: 'mental-health', category: 'Health' },
+    { name: 'Nutrition', slug: 'nutrition', category: 'Health' },
+    { name: 'Yoga', slug: 'yoga', category: 'Health' },
+    { name: 'Running', slug: 'running', category: 'Sports' },
+    { name: 'Football', slug: 'football', category: 'Sports' },
+    { name: 'Basketball', slug: 'basketball', category: 'Sports' },
+    { name: 'Cycling', slug: 'cycling', category: 'Sports' },
+    { name: 'Climbing', slug: 'climbing', category: 'Sports' },
+    { name: 'Travel', slug: 'travel', category: 'Lifestyle' },
+    { name: 'Food & Cooking', slug: 'food-cooking', category: 'Lifestyle' },
+    { name: 'Fashion', slug: 'fashion', category: 'Lifestyle' },
+    { name: 'Sustainability', slug: 'sustainability', category: 'Lifestyle' },
+    { name: 'Entrepreneurship', slug: 'entrepreneurship', category: 'Business' },
+    { name: 'Finance & Investing', slug: 'finance-investing', category: 'Business' },
+    { name: 'Marketing', slug: 'marketing', category: 'Business' },
+    { name: 'Science', slug: 'science', category: 'Education' },
+    { name: 'History', slug: 'history', category: 'Education' },
+    { name: 'Philosophy', slug: 'philosophy', category: 'Education' },
+    { name: 'Languages', slug: 'languages', category: 'Education' },
+    { name: 'Pets & Animals', slug: 'pets-animals', category: 'Lifestyle' },
+    { name: 'Volunteering', slug: 'volunteering', category: 'Community' },
+  ];
+
+  for (const interest of interests) {
+    await prisma.interest.upsert({
+      where: { slug: interest.slug },
+      update: { name: interest.name, category: interest.category, status: 'VALIDATED' },
+      create: { name: interest.name, slug: interest.slug, category: interest.category, status: 'VALIDATED' },
+    });
+    console.log(`Seeded interest: ${interest.name}`);
   }
 }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { ObservabilityModule } from './observability/observability.module';
 import { SentryExceptionFilter } from './common/filters/sentry-exception.filter';
 import { HttpMetricsInterceptor } from './observability/http-metrics.interceptor';
 import { SystemConfigModule } from './modules/system-config/system-config.module';
+import { InterestsModule } from './modules/interests/interests.module';
 import { FeedModule } from './modules/feed/feed.module';
 import { SearchModule } from './modules/search/search.module';
 import { QueuesModule } from './queues/queues.module';
@@ -34,6 +35,7 @@ import { BullboardModule } from './admin/queues/bullboard.module';
     HealthModule,
     ObservabilityModule,
     SystemConfigModule,
+    InterestsModule,
     FeedModule,
     SearchModule,
     QueuesModule,

--- a/src/auth/guards/supabase-auth.guard.ts
+++ b/src/auth/guards/supabase-auth.guard.ts
@@ -45,13 +45,12 @@ export class SupabaseAuthGuard implements CanActivate {
     try {
       // jsonwebtoken's verify() return type is a union that includes string,
       // but with a secret (not RequestHandler) it always returns JwtPayload.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment -- jsonwebtoken types are not fully resolvable; verify() always returns JwtPayload here
+
       const decoded = verify(
         token,
         SUPABASE_JWT_SECRET,
       ) as unknown as JwtPayload;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- decoded is cast from unknown via as unknown as JwtPayload above
       request.supabaseUser = decoded;
       request.supabaseToken = token;
       return true;

--- a/src/common/guards/jwt-admin.guard.spec.ts
+++ b/src/common/guards/jwt-admin.guard.spec.ts
@@ -24,7 +24,7 @@ import * as jwt from 'jsonwebtoken';
 
 // jwt.verify has multiple overloads; cast to a simple vi.Mock for type-safe
 // spy access in tests without triggering no-unsafe-* on overloaded signatures.
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- jwt module is fully mocked; .verify type is unresolvable at lint time
+
 const jwtVerifyMock = jwt.verify as unknown as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------

--- a/src/common/guards/jwt-admin.guard.ts
+++ b/src/common/guards/jwt-admin.guard.ts
@@ -64,7 +64,7 @@ export class JwtAdminGuard implements CanActivate {
     try {
       // jsonwebtoken's verify() return type is a union that includes string,
       // but with a secret (not RequestHandler) it always returns a JwtPayload object.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- jsonwebtoken types are not fully resolvable; verify() always returns JwtPayload here
+
       decoded = verify(token, jwtSecret) as unknown as SupabaseJwtPayload;
     } catch (err) {
       const name = err instanceof Error ? err.name : '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ async function bootstrap() {
       try {
         // jsonwebtoken's verify() return type is a union that includes string,
         // but with a secret (not RequestHandler) it always returns a JwtPayload object.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- jsonwebtoken types are not fully resolvable; verify() always returns JwtPayload here
+
         const decoded = verify(token, jwtSecret) as unknown as {
           app_metadata?: { role?: string };
         };

--- a/src/modules/interests/controllers/interests.controller.ts
+++ b/src/modules/interests/controllers/interests.controller.ts
@@ -11,7 +11,11 @@ export class InterestsController {
 
   @Get()
   @ApiOperation({ summary: 'List all validated interests' })
-  @ApiQuery({ name: 'category', required: false, description: 'Filter by category' })
+  @ApiQuery({
+    name: 'category',
+    required: false,
+    description: 'Filter by category',
+  })
   @ApiResponse({ status: 200, description: 'List of validated interests' })
   listInterests(@Query('category') category?: string) {
     return this.interestsService.listInterests(category);

--- a/src/modules/interests/controllers/interests.controller.ts
+++ b/src/modules/interests/controllers/interests.controller.ts
@@ -1,0 +1,19 @@
+// src/modules/interests/controllers/interests.controller.ts
+
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { InterestsService } from '../services/interests.service';
+
+@ApiTags('interests')
+@Controller('interests')
+export class InterestsController {
+  constructor(private readonly interestsService: InterestsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all validated interests' })
+  @ApiQuery({ name: 'category', required: false, description: 'Filter by category' })
+  @ApiResponse({ status: 200, description: 'List of validated interests' })
+  listInterests(@Query('category') category?: string) {
+    return this.interestsService.listInterests(category);
+  }
+}

--- a/src/modules/interests/controllers/user-interests.controller.ts
+++ b/src/modules/interests/controllers/user-interests.controller.ts
@@ -1,13 +1,6 @@
 // src/modules/interests/controllers/user-interests.controller.ts
 
-import {
-  Body,
-  Controller,
-  Get,
-  Put,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Put, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -34,19 +27,27 @@ export class UserInterestsController {
   @ApiResponse({ status: 200, description: 'User interests' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   getMyInterests(@Req() req: AuthenticatedRequest) {
-    return this.interestsService.getUserInterests(req.supabaseUser.sub as string);
+    return this.interestsService.getUserInterests(
+      req.supabaseUser.sub as string,
+    );
   }
 
   @Put('me/interests')
   @UseGuards(SupabaseAuthGuard)
-  @ApiOperation({ summary: 'Replace the authenticated user\'s interests' })
+  @ApiOperation({ summary: "Replace the authenticated user's interests" })
   @ApiResponse({ status: 200, description: 'Updated user interests' })
-  @ApiResponse({ status: 400, description: 'Invalid interest IDs or pending status' })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid interest IDs or pending status',
+  })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   setMyInterests(
     @Req() req: AuthenticatedRequest,
     @Body() dto: SetUserInterestsDto,
   ) {
-    return this.interestsService.setUserInterests(req.supabaseUser.sub as string, dto);
+    return this.interestsService.setUserInterests(
+      req.supabaseUser.sub as string,
+      dto,
+    );
   }
 }

--- a/src/modules/interests/controllers/user-interests.controller.ts
+++ b/src/modules/interests/controllers/user-interests.controller.ts
@@ -1,0 +1,52 @@
+// src/modules/interests/controllers/user-interests.controller.ts
+
+import {
+  Body,
+  Controller,
+  Get,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import type { JwtPayload } from 'jsonwebtoken';
+import { SupabaseAuthGuard } from '../../../auth/guards/supabase-auth.guard';
+import { InterestsService } from '../services/interests.service';
+import { SetUserInterestsDto } from '../dto/set-user-interests.dto';
+
+type AuthenticatedRequest = Request & { supabaseUser: JwtPayload };
+
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users')
+export class UserInterestsController {
+  constructor(private readonly interestsService: InterestsService) {}
+
+  @Get('me/interests')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiOperation({ summary: 'Get interests of the authenticated user' })
+  @ApiResponse({ status: 200, description: 'User interests' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getMyInterests(@Req() req: AuthenticatedRequest) {
+    return this.interestsService.getUserInterests(req.supabaseUser.sub as string);
+  }
+
+  @Put('me/interests')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiOperation({ summary: 'Replace the authenticated user\'s interests' })
+  @ApiResponse({ status: 200, description: 'Updated user interests' })
+  @ApiResponse({ status: 400, description: 'Invalid interest IDs or pending status' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  setMyInterests(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: SetUserInterestsDto,
+  ) {
+    return this.interestsService.setUserInterests(req.supabaseUser.sub as string, dto);
+  }
+}

--- a/src/modules/interests/dto/interest-response.dto.ts
+++ b/src/modules/interests/dto/interest-response.dto.ts
@@ -1,0 +1,20 @@
+// src/modules/interests/dto/interest-response.dto.ts
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InterestResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  slug: string;
+
+  @ApiProperty({ nullable: true })
+  category: string | null;
+
+  @ApiProperty({ enum: ['VALIDATED', 'PENDING', 'INACTIVE'] })
+  status: string;
+}

--- a/src/modules/interests/dto/set-user-interests.dto.ts
+++ b/src/modules/interests/dto/set-user-interests.dto.ts
@@ -1,0 +1,16 @@
+// src/modules/interests/dto/set-user-interests.dto.ts
+
+import { IsArray, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SetUserInterestsDto {
+  @ApiProperty({
+    type: [String],
+    format: 'uuid',
+    description: 'List of interest IDs to assign. Empty array resets all interests.',
+    example: ['11111111-1111-1111-1111-111111111111'],
+  })
+  @IsArray()
+  @IsUUID('4', { each: true })
+  interestIds: string[];
+}

--- a/src/modules/interests/dto/set-user-interests.dto.ts
+++ b/src/modules/interests/dto/set-user-interests.dto.ts
@@ -7,7 +7,8 @@ export class SetUserInterestsDto {
   @ApiProperty({
     type: [String],
     format: 'uuid',
-    description: 'List of interest IDs to assign. Empty array resets all interests.',
+    description:
+      'List of interest IDs to assign. Empty array resets all interests.',
     example: ['11111111-1111-1111-1111-111111111111'],
   })
   @IsArray()

--- a/src/modules/interests/dto/set-user-interests.dto.ts
+++ b/src/modules/interests/dto/set-user-interests.dto.ts
@@ -1,6 +1,6 @@
 // src/modules/interests/dto/set-user-interests.dto.ts
 
-import { IsArray, IsUUID } from 'class-validator';
+import { IsArray, IsUUID, ArrayUnique } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class SetUserInterestsDto {
@@ -13,5 +13,6 @@ export class SetUserInterestsDto {
   })
   @IsArray()
   @IsUUID('4', { each: true })
+  @ArrayUnique()
   interestIds: string[];
 }

--- a/src/modules/interests/dto/user-interests-response.dto.ts
+++ b/src/modules/interests/dto/user-interests-response.dto.ts
@@ -1,0 +1,9 @@
+// src/modules/interests/dto/user-interests-response.dto.ts
+
+import { ApiProperty } from '@nestjs/swagger';
+import { InterestResponseDto } from './interest-response.dto';
+
+export class UserInterestsResponseDto {
+  @ApiProperty({ type: [InterestResponseDto] })
+  items: InterestResponseDto[];
+}

--- a/src/modules/interests/interests.module.ts
+++ b/src/modules/interests/interests.module.ts
@@ -3,6 +3,7 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../../auth/auth.module';
 import { UsersModule } from '../users/users.module';
+import { ObservabilityModule } from '../../observability/observability.module';
 import { InterestsController } from './controllers/interests.controller';
 import { UserInterestsController } from './controllers/user-interests.controller';
 import { InterestsService } from './services/interests.service';
@@ -10,7 +11,7 @@ import { InterestsRepository } from './repositories/interests.repository';
 
 // PrismaModule is global — no need to import it here.
 @Module({
-  imports: [AuthModule, UsersModule],
+  imports: [AuthModule, UsersModule, ObservabilityModule],
   controllers: [InterestsController, UserInterestsController],
   providers: [InterestsService, InterestsRepository],
 })

--- a/src/modules/interests/interests.module.ts
+++ b/src/modules/interests/interests.module.ts
@@ -1,0 +1,17 @@
+// src/modules/interests/interests.module.ts
+
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../../auth/auth.module';
+import { UsersModule } from '../users/users.module';
+import { InterestsController } from './controllers/interests.controller';
+import { UserInterestsController } from './controllers/user-interests.controller';
+import { InterestsService } from './services/interests.service';
+import { InterestsRepository } from './repositories/interests.repository';
+
+// PrismaModule is global — no need to import it here.
+@Module({
+  imports: [AuthModule, UsersModule],
+  controllers: [InterestsController, UserInterestsController],
+  providers: [InterestsService, InterestsRepository],
+})
+export class InterestsModule {}

--- a/src/modules/interests/repositories/interests.repository.spec.ts
+++ b/src/modules/interests/repositories/interests.repository.spec.ts
@@ -1,0 +1,188 @@
+// src/modules/interests/repositories/interests.repository.spec.ts
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { InterestsRepository } from './interests.repository';
+
+const mockInterest = {
+  findMany: vi.fn(),
+};
+
+const mockUserInterest = {
+  findMany: vi.fn(),
+  deleteMany: vi.fn(),
+  createMany: vi.fn(),
+};
+
+const mockPrismaService = {
+  interest: mockInterest,
+  userInterest: mockUserInterest,
+  $transaction: vi.fn(),
+};
+
+describe('InterestsRepository', () => {
+  let repository: InterestsRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = new InterestsRepository(mockPrismaService as never);
+  });
+
+  describe('findAllValidated', () => {
+    it('calls prisma.interest.findMany with status VALIDATED ordered by name', async () => {
+      mockInterest.findMany.mockResolvedValue([]);
+
+      await repository.findAllValidated();
+
+      expect(mockInterest.findMany).toHaveBeenCalledOnce();
+      expect(mockInterest.findMany).toHaveBeenCalledWith({
+        where: { status: 'VALIDATED' },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('includes category filter when provided', async () => {
+      mockInterest.findMany.mockResolvedValue([]);
+
+      await repository.findAllValidated('Tech');
+
+      expect(mockInterest.findMany).toHaveBeenCalledWith({
+        where: { status: 'VALIDATED', category: 'Tech' },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('returns the array returned by prisma', async () => {
+      const interests = [
+        {
+          id: 'uuid-1',
+          name: 'Tech',
+          slug: 'tech',
+          category: 'Tech',
+          status: 'VALIDATED',
+        },
+      ];
+      mockInterest.findMany.mockResolvedValue(interests);
+
+      const result = await repository.findAllValidated();
+
+      expect(result).toEqual(interests);
+    });
+  });
+
+  describe('findManyByIds', () => {
+    it('calls prisma.interest.findMany with id in the provided array', async () => {
+      mockInterest.findMany.mockResolvedValue([]);
+      const ids = ['uuid-1', 'uuid-2'];
+
+      await repository.findManyByIds(ids);
+
+      expect(mockInterest.findMany).toHaveBeenCalledOnce();
+      expect(mockInterest.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ids } },
+      });
+    });
+
+    it('returns the interests found', async () => {
+      const interests = [
+        {
+          id: 'uuid-1',
+          name: 'Tech',
+          slug: 'tech',
+          category: 'Tech',
+          status: 'VALIDATED',
+        },
+      ];
+      mockInterest.findMany.mockResolvedValue(interests);
+
+      const result = await repository.findManyByIds(['uuid-1']);
+
+      expect(result).toEqual(interests);
+    });
+  });
+
+  describe('getUserInterests', () => {
+    it('calls prisma.userInterest.findMany with userId and includes interest', async () => {
+      mockUserInterest.findMany.mockResolvedValue([]);
+
+      await repository.getUserInterests('user-uuid');
+
+      expect(mockUserInterest.findMany).toHaveBeenCalledOnce();
+      expect(mockUserInterest.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid' },
+        include: { interest: true },
+      });
+    });
+
+    it('maps rows to InterestItem shape including slug', async () => {
+      const rows = [
+        {
+          userId: 'user-uuid',
+          interestId: 'uuid-1',
+          createdAt: new Date(),
+          interest: {
+            id: 'uuid-1',
+            name: 'Technology',
+            slug: 'technology',
+            category: 'Tech',
+            status: 'VALIDATED',
+          },
+        },
+      ];
+      mockUserInterest.findMany.mockResolvedValue(rows);
+
+      const result = await repository.getUserInterests('user-uuid');
+
+      expect(result).toEqual([
+        {
+          id: 'uuid-1',
+          name: 'Technology',
+          slug: 'technology',
+          category: 'Tech',
+          status: 'VALIDATED',
+        },
+      ]);
+    });
+  });
+
+  describe('setUserInterests', () => {
+    it('runs deleteMany and createMany inside a transaction', async () => {
+      const deleteManyOp = Symbol('deleteMany');
+      const createManyOp = Symbol('createMany');
+      mockUserInterest.deleteMany.mockReturnValue(deleteManyOp);
+      mockUserInterest.createMany.mockReturnValue(createManyOp);
+      mockPrismaService.$transaction.mockResolvedValue(undefined);
+
+      await repository.setUserInterests('user-uuid', ['uuid-1', 'uuid-2']);
+
+      expect(mockUserInterest.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid' },
+      });
+      expect(mockUserInterest.createMany).toHaveBeenCalledWith({
+        data: [
+          { userId: 'user-uuid', interestId: 'uuid-1' },
+          { userId: 'user-uuid', interestId: 'uuid-2' },
+        ],
+        skipDuplicates: true,
+      });
+      expect(mockPrismaService.$transaction).toHaveBeenCalledWith([
+        deleteManyOp,
+        createManyOp,
+      ]);
+    });
+
+    it('handles empty interestIds array', async () => {
+      const deleteManyOp = Symbol('deleteMany');
+      const createManyOp = Symbol('createMany');
+      mockUserInterest.deleteMany.mockReturnValue(deleteManyOp);
+      mockUserInterest.createMany.mockReturnValue(createManyOp);
+      mockPrismaService.$transaction.mockResolvedValue(undefined);
+
+      await repository.setUserInterests('user-uuid', []);
+
+      expect(mockUserInterest.createMany).toHaveBeenCalledWith({
+        data: [],
+        skipDuplicates: true,
+      });
+    });
+  });
+});

--- a/src/modules/interests/repositories/interests.repository.ts
+++ b/src/modules/interests/repositories/interests.repository.ts
@@ -7,6 +7,7 @@ import type { Interest } from '@prisma/client';
 export interface InterestItem {
   id: string;
   name: string;
+  slug: string;
   category: string | null;
   status: string;
 }
@@ -39,6 +40,7 @@ export class InterestsRepository {
     return rows.map((r) => ({
       id: r.interest.id,
       name: r.interest.name,
+      slug: r.interest.slug,
       category: r.interest.category,
       status: r.interest.status,
     }));

--- a/src/modules/interests/repositories/interests.repository.ts
+++ b/src/modules/interests/repositories/interests.repository.ts
@@ -1,0 +1,56 @@
+// src/modules/interests/repositories/interests.repository.ts
+
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+import type { Interest } from '@prisma/client';
+
+export interface InterestItem {
+  id: string;
+  name: string;
+  category: string | null;
+  status: string;
+}
+
+@Injectable()
+export class InterestsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAllValidated(category?: string): Promise<Interest[]> {
+    return this.prisma.interest.findMany({
+      where: {
+        status: 'VALIDATED',
+        ...(category ? { category } : {}),
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async findManyByIds(ids: string[]): Promise<Interest[]> {
+    return this.prisma.interest.findMany({
+      where: { id: { in: ids } },
+    });
+  }
+
+  async getUserInterests(userId: string): Promise<InterestItem[]> {
+    const rows = await this.prisma.userInterest.findMany({
+      where: { userId },
+      include: { interest: true },
+    });
+    return rows.map((r) => ({
+      id: r.interest.id,
+      name: r.interest.name,
+      category: r.interest.category,
+      status: r.interest.status,
+    }));
+  }
+
+  async setUserInterests(userId: string, interestIds: string[]): Promise<void> {
+    await this.prisma.$transaction([
+      this.prisma.userInterest.deleteMany({ where: { userId } }),
+      this.prisma.userInterest.createMany({
+        data: interestIds.map((interestId) => ({ userId, interestId })),
+        skipDuplicates: true,
+      }),
+    ]);
+  }
+}

--- a/src/modules/interests/services/interests.service.spec.ts
+++ b/src/modules/interests/services/interests.service.spec.ts
@@ -1,0 +1,199 @@
+// src/modules/interests/services/interests.service.spec.ts
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { InterestsService } from './interests.service';
+
+const mockInterestsRepository = {
+  findAllValidated: vi.fn(),
+  findManyByIds: vi.fn(),
+  getUserInterests: vi.fn(),
+  setUserInterests: vi.fn(),
+};
+
+const mockUsersRepository = {
+  findBySupabaseId: vi.fn(),
+};
+
+const validatedInterest = {
+  id: 'uuid-1',
+  name: 'Technology',
+  slug: 'technology',
+  category: 'Tech',
+  status: 'VALIDATED',
+};
+
+const activeUser = {
+  id: 'user-uuid',
+  supabaseId: 'supabase-uuid',
+  email: 'test@example.com',
+  username: 'testuser',
+};
+
+describe('InterestsService', () => {
+  let service: InterestsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new InterestsService(
+      mockInterestsRepository as never,
+      mockUsersRepository as never,
+    );
+  });
+
+  describe('listInterests', () => {
+    it('returns items mapped from repository including slug', async () => {
+      mockInterestsRepository.findAllValidated.mockResolvedValue([
+        validatedInterest,
+      ]);
+
+      const result = await service.listInterests();
+
+      expect(mockInterestsRepository.findAllValidated).toHaveBeenCalledWith(
+        undefined,
+      );
+      expect(result).toEqual({
+        items: [
+          {
+            id: 'uuid-1',
+            name: 'Technology',
+            slug: 'technology',
+            category: 'Tech',
+            status: 'VALIDATED',
+          },
+        ],
+      });
+    });
+
+    it('passes category filter to repository', async () => {
+      mockInterestsRepository.findAllValidated.mockResolvedValue([]);
+
+      await service.listInterests('Tech');
+
+      expect(mockInterestsRepository.findAllValidated).toHaveBeenCalledWith(
+        'Tech',
+      );
+    });
+
+    it('returns empty items array when no interests exist', async () => {
+      mockInterestsRepository.findAllValidated.mockResolvedValue([]);
+
+      const result = await service.listInterests();
+
+      expect(result).toEqual({ items: [] });
+    });
+  });
+
+  describe('getUserInterests', () => {
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(null);
+
+      await expect(
+        service.getUserInterests('unknown-supabase-id'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('returns user interests when user exists', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.getUserInterests.mockResolvedValue([
+        validatedInterest,
+      ]);
+
+      const result = await service.getUserInterests('supabase-uuid');
+
+      expect(mockInterestsRepository.getUserInterests).toHaveBeenCalledWith(
+        'user-uuid',
+      );
+      expect(result).toEqual({ items: [validatedInterest] });
+    });
+  });
+
+  describe('setUserInterests', () => {
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(null);
+
+      await expect(
+        service.setUserInterests('unknown', { interestIds: ['uuid-1'] }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws BadRequestException when an interest id does not exist', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.findManyByIds.mockResolvedValue([]);
+
+      await expect(
+        service.setUserInterests('supabase-uuid', {
+          interestIds: ['uuid-missing'],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when an interest is not VALIDATED', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.findManyByIds.mockResolvedValue([
+        { ...validatedInterest, status: 'PENDING' },
+      ]);
+
+      await expect(
+        service.setUserInterests('supabase-uuid', { interestIds: ['uuid-1'] }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('deduplicates interest ids before processing', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.findManyByIds.mockResolvedValue([
+        validatedInterest,
+      ]);
+      mockInterestsRepository.setUserInterests.mockResolvedValue(undefined);
+      mockInterestsRepository.getUserInterests.mockResolvedValue([
+        validatedInterest,
+      ]);
+
+      await service.setUserInterests('supabase-uuid', {
+        interestIds: ['uuid-1', 'uuid-1'],
+      });
+
+      expect(mockInterestsRepository.findManyByIds).toHaveBeenCalledWith([
+        'uuid-1',
+      ]);
+    });
+
+    it('replaces user interests and returns updated list', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.findManyByIds.mockResolvedValue([
+        validatedInterest,
+      ]);
+      mockInterestsRepository.setUserInterests.mockResolvedValue(undefined);
+      mockInterestsRepository.getUserInterests.mockResolvedValue([
+        validatedInterest,
+      ]);
+
+      const result = await service.setUserInterests('supabase-uuid', {
+        interestIds: ['uuid-1'],
+      });
+
+      expect(mockInterestsRepository.setUserInterests).toHaveBeenCalledWith(
+        'user-uuid',
+        ['uuid-1'],
+      );
+      expect(result).toEqual({ items: [validatedInterest] });
+    });
+
+    it('allows empty interestIds to reset all interests', async () => {
+      mockUsersRepository.findBySupabaseId.mockResolvedValue(activeUser);
+      mockInterestsRepository.setUserInterests.mockResolvedValue(undefined);
+      mockInterestsRepository.getUserInterests.mockResolvedValue([]);
+
+      const result = await service.setUserInterests('supabase-uuid', {
+        interestIds: [],
+      });
+
+      expect(mockInterestsRepository.findManyByIds).not.toHaveBeenCalled();
+      expect(mockInterestsRepository.setUserInterests).toHaveBeenCalledWith(
+        'user-uuid',
+        [],
+      );
+      expect(result).toEqual({ items: [] });
+    });
+  });
+});

--- a/src/modules/interests/services/interests.service.ts
+++ b/src/modules/interests/services/interests.service.ts
@@ -27,6 +27,7 @@ export class InterestsService {
     const items: InterestItem[] = interests.map((i) => ({
       id: i.id,
       name: i.name,
+      slug: i.slug,
       category: i.category,
       status: i.status,
     }));

--- a/src/modules/interests/services/interests.service.ts
+++ b/src/modules/interests/services/interests.service.ts
@@ -6,7 +6,10 @@ import {
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import { InterestsRepository, InterestItem } from '../repositories/interests.repository';
+import {
+  InterestsRepository,
+  InterestItem,
+} from '../repositories/interests.repository';
 import { UsersRepository } from '../../users/repositories/users.repository';
 import { SetUserInterestsDto } from '../dto/set-user-interests.dto';
 
@@ -27,11 +30,17 @@ export class InterestsService {
       category: i.category,
       status: i.status,
     }));
-    this.logger.log({ action: 'interests.list', count: items.length, category });
+    this.logger.log({
+      action: 'interests.list',
+      count: items.length,
+      category,
+    });
     return { items };
   }
 
-  async getUserInterests(supabaseId: string): Promise<{ items: InterestItem[] }> {
+  async getUserInterests(
+    supabaseId: string,
+  ): Promise<{ items: InterestItem[] }> {
     const user = await this.usersRepository.findBySupabaseId(supabaseId);
     if (!user) throw new UnauthorizedException();
     const items = await this.interestsRepository.getUserInterests(user.id);
@@ -59,12 +68,18 @@ export class InterestsService {
 
       const hasPending = found.some((i) => i.status !== 'VALIDATED');
       if (hasPending) {
-        throw new BadRequestException('Cannot assign interests with pending status.');
+        throw new BadRequestException(
+          'Cannot assign interests with pending status.',
+        );
       }
     }
 
     await this.interestsRepository.setUserInterests(user.id, uniqueIds);
-    this.logger.log({ action: 'userInterests.set', userId: user.id, count: uniqueIds.length });
+    this.logger.log({
+      action: 'userInterests.set',
+      userId: user.id,
+      count: uniqueIds.length,
+    });
 
     const items = await this.interestsRepository.getUserInterests(user.id);
     return { items };

--- a/src/modules/interests/services/interests.service.ts
+++ b/src/modules/interests/services/interests.service.ts
@@ -1,0 +1,72 @@
+// src/modules/interests/services/interests.service.ts
+
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InterestsRepository, InterestItem } from '../repositories/interests.repository';
+import { UsersRepository } from '../../users/repositories/users.repository';
+import { SetUserInterestsDto } from '../dto/set-user-interests.dto';
+
+@Injectable()
+export class InterestsService {
+  private readonly logger = new Logger(InterestsService.name);
+
+  constructor(
+    private readonly interestsRepository: InterestsRepository,
+    private readonly usersRepository: UsersRepository,
+  ) {}
+
+  async listInterests(category?: string): Promise<{ items: InterestItem[] }> {
+    const interests = await this.interestsRepository.findAllValidated(category);
+    const items: InterestItem[] = interests.map((i) => ({
+      id: i.id,
+      name: i.name,
+      category: i.category,
+      status: i.status,
+    }));
+    this.logger.log({ action: 'interests.list', count: items.length, category });
+    return { items };
+  }
+
+  async getUserInterests(supabaseId: string): Promise<{ items: InterestItem[] }> {
+    const user = await this.usersRepository.findBySupabaseId(supabaseId);
+    if (!user) throw new UnauthorizedException();
+    const items = await this.interestsRepository.getUserInterests(user.id);
+    this.logger.log({ action: 'userInterests.get', userId: user.id });
+    return { items };
+  }
+
+  async setUserInterests(
+    supabaseId: string,
+    dto: SetUserInterestsDto,
+  ): Promise<{ items: InterestItem[] }> {
+    const user = await this.usersRepository.findBySupabaseId(supabaseId);
+    if (!user) throw new UnauthorizedException();
+
+    const uniqueIds = [...new Set(dto.interestIds)];
+
+    if (uniqueIds.length > 0) {
+      const found = await this.interestsRepository.findManyByIds(uniqueIds);
+
+      if (found.length !== uniqueIds.length) {
+        throw new BadRequestException(
+          'One or more interest IDs do not exist or are invalid.',
+        );
+      }
+
+      const hasPending = found.some((i) => i.status !== 'VALIDATED');
+      if (hasPending) {
+        throw new BadRequestException('Cannot assign interests with pending status.');
+      }
+    }
+
+    await this.interestsRepository.setUserInterests(user.id, uniqueIds);
+    this.logger.log({ action: 'userInterests.set', userId: user.id, count: uniqueIds.length });
+
+    const items = await this.interestsRepository.getUserInterests(user.id);
+    return { items };
+  }
+}

--- a/src/modules/users/repositories/users.repository.ts
+++ b/src/modules/users/repositories/users.repository.ts
@@ -43,4 +43,13 @@ export class UsersRepository {
       },
     });
   }
+
+  async findBySupabaseId(supabaseId: string): Promise<User | null> {
+    return this.prisma.user.findFirst({
+      where: {
+        supabaseId,
+        deletedAt: null,
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Resumen

- Agrega campos `category` y `status` (enum `VALIDATED` / `PENDING`) al modelo `Interest` en Prisma junto con su migración y un
  índice en `status`.
- Implementa `InterestsModule` completo siguiendo la arquitectura de capas del proyecto (controller → service → repository → dto).
- `GET /interests` expone el catálogo público de intereses validados con filtro opcional por categoría (`?category=`).
- `GET /users/me/interests` y `PUT /users/me/interests` permiten al usuario autenticado consultar y reemplazar sus intereses;
protegidos con `SupabaseAuthGuard`.
- La operación `PUT` realiza un replace atómico vía transacción Prisma; array vacío elimina todos los intereses del usuario.
- Valida que los IDs recibidos existan y tengan `status = VALIDATED`; devuelve `400` en caso contrario.
- Agrega `UsersRepository.findBySupabaseId()` reutilizable para resolver el usuario interno desde el JWT.

## Plan de pruebas

- [ ] `pnpm run lint` pasa sin errores
- [ ] `pnpm run test` pasa sin regresiones
- [ ] `GET /interests` devuelve solo intereses con `status = VALIDATED`
- [ ] `GET /interests?category=<valor>` filtra correctamente por categoría
- [ ] `GET /users/me/interests` sin token devuelve `401`
- [ ] `GET /users/me/interests` con token válido devuelve los intereses del usuario
- [ ] `PUT /users/me/interests` con IDs válidos reemplaza los intereses y devuelve la lista actualizada
- [ ] `PUT /users/me/interests` con body `{ "interestIds": [] }` elimina todos los intereses del usuario
- [ ] `PUT /users/me/interests` con un ID inexistente devuelve `400`
- [ ] `PUT /users/me/interests` con un ID de interés en estado `PENDING` devuelve `400`
- [ ] `PUT /users/me/interests` sin token devuelve `401`
- [ ] La migración aplica correctamente en base de datos limpia (`npx prisma migrate dev`)

Closes #83 