### PR TITLE
fix: ensure statusCode in error responses for NestJS v11

### DIFF
--- a/src/common/filters/sentry-exception.filter.spec.ts
+++ b/src/common/filters/sentry-exception.filter.spec.ts
@@ -130,4 +130,47 @@ describe('SentryExceptionFilter', () => {
       message: 'Internal server error',
     });
   });
+
+  // NestJS v11: when an object is passed to BadRequestException, getResponse()
+  // returns the object WITHOUT statusCode. The filter must inject it for a
+  // consistent API contract.
+  it('injects statusCode when HttpException body lacks it (NestJS v11 object payload)', () => {
+    // Simulates: new BadRequestException({ message: 'Errores', errors: [...] })
+    // where getResponse() returns { message, errors } without statusCode.
+    const exception = new HttpException(
+      {
+        message: 'Errores de validación',
+        errors: [{ field: 'email', errors: ['invalid'] }],
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+    const host = buildHost();
+
+    filter.catch(exception, host as any);
+
+    expect(host.response.status).toHaveBeenCalledWith(400);
+    expect(host.json).toHaveBeenCalledWith({
+      statusCode: 400,
+      message: 'Errores de validación',
+      errors: [{ field: 'email', errors: ['invalid'] }],
+    });
+  });
+
+  it('injects statusCode when HttpException body is a string', () => {
+    // Simulates: new HttpException('plain message', 418)
+    // where getResponse() returns 'plain message' (a string).
+    const exception = new HttpException(
+      'plain message',
+      HttpStatus.I_AM_A_TEAPOT,
+    );
+    const host = buildHost();
+
+    filter.catch(exception, host as any);
+
+    expect(host.response.status).toHaveBeenCalledWith(418);
+    expect(host.json).toHaveBeenCalledWith({
+      statusCode: 418,
+      message: 'plain message',
+    });
+  });
 });

--- a/src/common/filters/sentry-exception.filter.ts
+++ b/src/common/filters/sentry-exception.filter.ts
@@ -44,7 +44,18 @@ export class SentryExceptionFilter implements ExceptionFilter {
 
     if (isHttpException) {
       const responseBody = exception.getResponse();
-      response.status(status).json(responseBody);
+
+      // NestJS v11: when an object is passed to HttpException subclasses,
+      // getResponse() returns that object WITHOUT statusCode/error. To keep
+      // a consistent API contract we always inject statusCode into the body
+      // so every error response includes it, regardless of how the exception
+      // was constructed (string vs object payload).
+      const body =
+        typeof responseBody === 'object' && responseBody !== null
+          ? { statusCode: status, ...responseBody }
+          : { statusCode: status, message: String(responseBody) };
+
+      response.status(status).json(body);
     } else if (
       typeof exception === 'object' &&
       exception !== null &&

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -14,6 +14,15 @@ import cookieParser from 'cookie-parser';
 import { AppModule } from './../src/app.module';
 import { PrismaService } from './../src/prisma/prisma.service';
 import { AuthService } from './../src/auth/auth.service';
+import { QueueService } from './../src/queues/queue.service';
+import { DefaultWorker } from './../src/queues/workers/default.worker';
+import { QueueMonitorService } from './../src/queues/alerts/queue-monitor.service';
+import { AppMonitorService } from './../src/observability/alerts/app-monitor.service';
+import { SecurityMonitorService } from './../src/observability/alerts/security-monitor.service';
+import { DiscordAlertService } from './../src/queues/alerts/discord-alert.service';
+import { MetricsService } from './../src/observability/metrics/metrics.service';
+import { BULLBOARD_ADAPTER } from './../src/admin/queues/bullboard.module';
+import { ExpressAdapter } from '@bull-board/express';
 
 interface ValidationErrorBody {
   errors: Array<{ field: string; errors: string[] }>;
@@ -107,16 +116,53 @@ describe('POST /api/v1/auth/register (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     })
+      // Prisma is mocked so e2e tests don't need a real DB connection
       .overrideProvider(PrismaService)
       .useValue({
         $connect: vi.fn(),
         $disconnect: vi.fn(),
       })
+      // AuthService is mocked to control register/login/logout behaviour
       .overrideProvider(AuthService)
       .useValue({
         register: mockRegister,
         login: vi.fn(),
         logout: vi.fn(),
+      })
+      // Redis-dependent providers are stubbed so e2e tests don't need a
+      // running Redis instance. Without these overrides, BullMQ queues and
+      // IORedis clients create real connections that produce "Connection is
+      // closed" unhandled rejections during app teardown.
+      .overrideProvider(QueueService)
+      .useValue({
+        queue: { on: vi.fn(), close: vi.fn(), removeAllListeners: vi.fn() },
+        onModuleDestroy: vi.fn(),
+      })
+      .overrideProvider(DefaultWorker)
+      .useValue({ onModuleInit: vi.fn(), onModuleDestroy: vi.fn() })
+      .overrideProvider(QueueMonitorService)
+      .useValue({ onModuleInit: vi.fn(), onModuleDestroy: vi.fn() })
+      .overrideProvider(AppMonitorService)
+      .useValue({ onModuleInit: vi.fn(), onModuleDestroy: vi.fn() })
+      .overrideProvider(SecurityMonitorService)
+      .useValue({ onModuleInit: vi.fn(), onModuleDestroy: vi.fn() })
+      .overrideProvider(DiscordAlertService)
+      .useValue({ sendAlert: vi.fn() })
+      .overrideProvider(MetricsService)
+      .useValue({
+        onModuleInit: vi.fn(),
+        onModuleDestroy: vi.fn(),
+        normaliseRoute: vi.fn((route: string) => route),
+        httpRequestsTotal: { inc: vi.fn(), labels: vi.fn() },
+        httpRequestDurationSeconds: { observe: vi.fn(), labels: vi.fn() },
+      })
+      .overrideProvider(BULLBOARD_ADAPTER)
+      .useFactory({
+        factory: () => {
+          const adapter = new ExpressAdapter();
+          adapter.setBasePath('/admin/queues');
+          return adapter;
+        },
       })
       .compile();
 
@@ -302,8 +348,12 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send(VALID_PAYLOAD)
       .expect(400);
 
-    // The body should contain the code property
+// NestJS v11: getResponse() returns the raw object passed to BadRequestException.
+    // The SentryExceptionFilter ensures statusCode is present in the body.
+    // { code: 'REGISTER_ERROR', message: error.message } → body becomes
+    // { statusCode: 400, code: 'REGISTER_ERROR', message: 'Supabase is down' }
     expect(response.body).toMatchObject({
+      statusCode: 400,
       code: 'REGISTER_ERROR',
       message: 'Supabase is down',
     });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -348,7 +348,7 @@ describe('POST /api/v1/auth/register (e2e)', () => {
       .send(VALID_PAYLOAD)
       .expect(400);
 
-// NestJS v11: getResponse() returns the raw object passed to BadRequestException.
+    // NestJS v11: getResponse() returns the raw object passed to BadRequestException.
     // The SentryExceptionFilter ensures statusCode is present in the body.
     // { code: 'REGISTER_ERROR', message: error.message } → body becomes
     // { statusCode: 400, code: 'REGISTER_ERROR', message: 'Supabase is down' }


### PR DESCRIPTION
## Summary
Fixes the SentryExceptionFilter to ensure statusCode is always present in error responses, compatible with NestJS v11 behavior.
## Problem
In NestJS v11, when an object is passed to BadRequestException (e.g., new BadRequestException({ message: 'Errores', errors: [...] })), the getResponse() method returns that object WITHOUT statusCode. This breaks the API contract.
## Solution
Modified SentryExceptionFilter to always inject statusCode into the response body.
## Changes
- sentry-exception.filter.ts: Filter now injects statusCode
- sentry-exception.filter.spec.ts: Added unit tests
- auth.e2e-spec.ts: Added Redis stubs + updated test expectation
## Testing
- pnpm test -- sentry-exception.filter ✅