### PR TITLE
feat: (#41) enviar access_token como cookie httpOnly en el login

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -58,11 +58,16 @@ describe('AuthController', () => {
     );
   });
 
-  it('should login a user', async () => {
+  it('should login a user and set three cookies (access_token, refresh_token, XSRF-TOKEN)', async () => {
     const dto: LoginDto = { email: 'test@gmail.com', password: 'password123' };
     (service.login as Mock).mockResolvedValue({
-      session: { access_token: 'access-jwt', refresh_token: 'refresh-jwt' },
-      user: { id: 'user-id', email: 'test@gmail.com' },
+      session: {
+        access_token: 'access-jwt',
+        refresh_token: 'refresh-jwt',
+        expires_in: 3600,
+      },
+      localUser: { id: 'user-id', username: 'testuser', email: 'test@gmail.com' },
+      csrfToken: 'csrf-token-abc',
     });
     const req = {
       ip: '127.0.0.1',
@@ -76,10 +81,18 @@ describe('AuthController', () => {
     const result = await controller.login(dto, req, res);
     expect(result.success).toBe(true);
     expect(result.data).toEqual({
-      accessToken: 'access-jwt',
-      user: { id: 'user-id', email: 'test@gmail.com' },
+      id: 'user-id',
+      username: 'testuser',
+      email: 'test@gmail.com',
     });
-    expect((res.cookie as Mock).mock.calls.length).toBe(2);
+    // Three cookies: access_token, refresh_token, XSRF-TOKEN
+    expect((res.cookie as Mock).mock.calls.length).toBe(3);
+    const cookieNames = (res.cookie as Mock).mock.calls.map(
+      (c: unknown[]) => c[0],
+    );
+    expect(cookieNames).toContain('access_token');
+    expect(cookieNames).toContain('refresh_token');
+    expect(cookieNames).toContain('XSRF-TOKEN');
   });
 
   it('should handle login error', async () => {
@@ -192,13 +205,14 @@ describe('AuthController', () => {
 
       await controller.logout(req, res);
 
-      // clearCookie must be called at least once for refresh_token and XSRF-TOKEN
+      // clearCookie must be called for access_token, refresh_token, and XSRF-TOKEN
       expect(
         (res.clearCookie as Mock).mock.calls.length,
-      ).toBeGreaterThanOrEqual(2);
+      ).toBeGreaterThanOrEqual(3);
       const clearedNames = (res.clearCookie as Mock).mock.calls.map(
         (c: unknown[]) => c[0],
       );
+      expect(clearedNames).toContain('access_token');
       expect(clearedNames).toContain('refresh_token');
       expect(clearedNames).toContain('XSRF-TOKEN');
     });

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -66,7 +66,11 @@ describe('AuthController', () => {
         refresh_token: 'refresh-jwt',
         expires_in: 3600,
       },
-      localUser: { id: 'user-id', username: 'testuser', email: 'test@gmail.com' },
+      localUser: {
+        id: 'user-id',
+        username: 'testuser',
+        email: 'test@gmail.com',
+      },
       csrfToken: 'csrf-token-abc',
     });
     const req = {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -25,10 +25,13 @@ import { AuthService } from './auth.service';
 import { RegisterRequestDto } from './dto/register.request.dto';
 import { RegisterResponseDto } from './dto/register.response.dto';
 import { LoginDto } from './dto/login.dto';
+import { LoginResponseDto } from './dto/login.response.dto';
 import {
   clearAuthCookies,
+  ACCESS_TOKEN_COOKIE,
   REFRESH_TOKEN_COOKIE,
   XSRF_TOKEN_COOKIE,
+  buildAccessTokenCookieOptions,
   buildRefreshTokenCookieOptions,
   buildCsrfCookieOptions,
 } from '../common/utils/cookies';
@@ -78,58 +81,80 @@ export class AuthController {
   }
 
   @Post('login')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Authenticate with email and password' })
+  @ApiResponse({
+    status: 200,
+    description: 'Login successful — tokens set as httpOnly cookies',
+    type: LoginResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error — missing or malformed fields',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — invalid credentials',
+  })
   async login(
     @Body() dto: LoginDto,
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
-  ) {
-    try {
-      const result = await this.authService.login(dto, {
-        ipAddress: req.ip,
-        userAgent:
-          typeof req.headers['user-agent'] === 'string'
-            ? req.headers['user-agent']
-            : undefined,
-      });
-      const refreshToken = result.session?.refresh_token;
-      const accessToken = result.session?.access_token;
+  ): Promise<LoginResponseDto> {
+    const result = await this.authService.login(dto, {
+      ipAddress: req.ip,
+      userAgent:
+        typeof req.headers['user-agent'] === 'string'
+          ? req.headers['user-agent']
+          : undefined,
+    });
 
-      if (!refreshToken || !accessToken) {
-        throw new BadRequestException({
-          code: 'LOGIN_ERROR',
-          message: 'Invalid authentication response',
-        });
-      }
+    const refreshToken = result.session?.refresh_token;
+    const accessToken = result.session?.access_token;
 
-      const refreshExpiresAt = new Date(Date.now() + this.refreshTtlMs);
-      const { csrfToken } = result;
-
-      res.cookie(
-        REFRESH_TOKEN_COOKIE,
-        refreshToken,
-        buildRefreshTokenCookieOptions(refreshExpiresAt),
-      );
-      res.cookie(
-        XSRF_TOKEN_COOKIE,
-        csrfToken,
-        buildCsrfCookieOptions(refreshExpiresAt),
-      );
-
-      return {
-        success: true,
-        data: {
-          accessToken,
-          user: result.user ?? null,
-        },
-        message: 'Login successful',
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      throw new BadRequestException({
-        message,
-        code: 'LOGIN_ERROR',
-      });
+    if (!refreshToken || !accessToken) {
+      throw new UnauthorizedException('Invalid authentication response');
     }
+
+    const refreshExpiresAt = new Date(Date.now() + this.refreshTtlMs);
+    // Supabase access tokens expire in `expires_in` seconds (default 3600).
+    // Fall back to 3600 s if the field is absent.
+    const accessTokenTtlMs =
+      ((result.session as { expires_in?: number } | null)?.expires_in ?? 3600) *
+      1000;
+    const accessTokenExpiresAt = new Date(Date.now() + accessTokenTtlMs);
+    const { csrfToken } = result;
+
+    res.cookie(
+      ACCESS_TOKEN_COOKIE,
+      accessToken,
+      buildAccessTokenCookieOptions(accessTokenExpiresAt),
+    );
+    res.cookie(
+      REFRESH_TOKEN_COOKIE,
+      refreshToken,
+      buildRefreshTokenCookieOptions(refreshExpiresAt),
+    );
+    res.cookie(
+      XSRF_TOKEN_COOKIE,
+      csrfToken,
+      buildCsrfCookieOptions(refreshExpiresAt),
+    );
+
+    const user = result.localUser;
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    return {
+      success: true,
+      data: {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+      },
+      message: 'Login successful',
+    };
   }
 
   @Post('refresh')

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -185,13 +185,21 @@ describe('AuthService.register', () => {
 });
 
 describe('AuthService.login', () => {
-  it('calls Supabase signInWithPassword and returns session data', async () => {
+  it('calls Supabase signInWithPassword and returns session with localUser', async () => {
     const dto = { email: 'user@example.com', password: 'secret123' };
-    const sessionData = { session: { access_token: 'jwt-token' }, user: {} };
+    const sessionData = {
+      session: { access_token: 'jwt-token', refresh_token: 'refresh-token' },
+      user: { id: 'supabase-id-1' },
+    };
 
     mockSignInWithPassword.mockResolvedValue({
       data: sessionData,
       error: null,
+    });
+    mockUsersRepository.findBySupabaseId.mockResolvedValue({
+      id: 'local-uuid-1',
+      username: 'testuser',
+      email: dto.email,
     });
 
     const service = buildService();
@@ -203,9 +211,11 @@ describe('AuthService.login', () => {
     });
     expect(result).toEqual({
       session: sessionData.session,
-      user: sessionData.user,
+      localUser: { id: 'local-uuid-1', username: 'testuser', email: dto.email },
       csrfToken: expect.any(String) as unknown,
     });
+    // localUser must NOT expose passwordHash
+    expect(result.localUser).not.toHaveProperty('passwordHash');
   });
 
   it('persists hashed refresh token on successful login when local user exists', async () => {
@@ -221,6 +231,8 @@ describe('AuthService.login', () => {
     });
     mockUsersRepository.findBySupabaseId.mockResolvedValue({
       id: 'local-user-1',
+      username: 'testuser',
+      email: dto.email,
     });
 
     const service = buildService();
@@ -235,11 +247,31 @@ describe('AuthService.login', () => {
     expect(arg.tokenHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('throws when Supabase returns an error', async () => {
+  it('returns null localUser when Supabase user is not found in local DB', async () => {
+    const dto = { email: 'user@example.com', password: 'secret123' };
+    const sessionData = {
+      session: { access_token: 'jwt-token', refresh_token: 'refresh-token' },
+      user: { id: 'supabase-id-1' },
+    };
+
+    mockSignInWithPassword.mockResolvedValue({
+      data: sessionData,
+      error: null,
+    });
+    mockUsersRepository.findBySupabaseId.mockResolvedValue(null);
+
+    const service = buildService();
+    const result = await service.login(dto);
+
+    expect(result.localUser).toBeNull();
+    expect(mockAuthRepository.createRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('throws UnauthorizedException (401) when Supabase returns an error', async () => {
     const dto = { email: 'user@example.com', password: 'wrong' };
     mockSignInWithPassword.mockResolvedValue({
       data: null,
-      error: { message: 'Invalid credentials' },
+      error: { message: 'Invalid login credentials' },
     });
 
     const service = buildService();

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -129,7 +129,11 @@ export class AuthService {
   async login(
     data: LoginDto,
     metadata?: { ipAddress?: string; userAgent?: string },
-  ) {
+  ): Promise<{
+    session: { access_token: string; refresh_token: string } | null;
+    localUser: { id: string; username: string; email: string } | null;
+    csrfToken: string;
+  }> {
     const supabase = getSupabaseClient();
     const { email, password } = data;
     const { data: signInData, error } = await supabase.auth.signInWithPassword({
@@ -138,27 +142,39 @@ export class AuthService {
     });
     if (error) {
       this.securityMonitor.recordFailedLogin();
-      throw new Error(error.message);
+      throw new UnauthorizedException('Invalid credentials');
     }
 
     const refreshToken = signInData.session?.refresh_token;
     const supabaseUserId = signInData.user?.id;
-    if (refreshToken && supabaseUserId) {
-      const user = await this.usersRepository.findBySupabaseId(supabaseUserId);
-      if (user) {
-        await this.authRepository.createRefreshToken({
-          userId: user.id,
-          tokenHash: this.hashToken(refreshToken),
-          expiresAt: new Date(Date.now() + this.refreshTtlMs),
-          ipAddress: metadata?.ipAddress,
-          userAgent: metadata?.userAgent,
-        });
+
+    let localUser: { id: string; username: string; email: string } | null =
+      null;
+
+    if (supabaseUserId) {
+      const dbUser =
+        await this.usersRepository.findBySupabaseId(supabaseUserId);
+      if (dbUser) {
+        localUser = { id: dbUser.id, username: dbUser.username, email: dbUser.email };
+
+        if (refreshToken) {
+          await this.authRepository.createRefreshToken({
+            userId: dbUser.id,
+            tokenHash: this.hashToken(refreshToken),
+            expiresAt: new Date(Date.now() + this.refreshTtlMs),
+            ipAddress: metadata?.ipAddress,
+            userAgent: metadata?.userAgent,
+          });
+        }
       }
     }
 
     return {
-      session: signInData.session,
-      user: signInData.user,
+      session: signInData.session as {
+        access_token: string;
+        refresh_token: string;
+      } | null,
+      localUser,
       csrfToken: this.generateCsrfToken(),
     };
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -155,7 +155,11 @@ export class AuthService {
       const dbUser =
         await this.usersRepository.findBySupabaseId(supabaseUserId);
       if (dbUser) {
-        localUser = { id: dbUser.id, username: dbUser.username, email: dbUser.email };
+        localUser = {
+          id: dbUser.id,
+          username: dbUser.username,
+          email: dbUser.email,
+        };
 
         if (refreshToken) {
           await this.authRepository.createRefreshToken({

--- a/src/auth/dto/login.response.dto.ts
+++ b/src/auth/dto/login.response.dto.ts
@@ -1,0 +1,43 @@
+// src/auth/dto/login.response.dto.ts
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginUserDataDto {
+  @ApiProperty({
+    description: 'Internal user UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'Unique username',
+    example: 'johndoe',
+  })
+  username!: string;
+
+  @ApiProperty({
+    description: 'User email address',
+    example: 'johndoe@example.com',
+  })
+  email!: string;
+}
+
+export class LoginResponseDto {
+  @ApiProperty({
+    description: 'Indicates whether the operation succeeded',
+    example: true,
+  })
+  success!: boolean;
+
+  @ApiProperty({
+    description: 'Public user data — no tokens or sensitive fields',
+    type: LoginUserDataDto,
+  })
+  data!: LoginUserDataDto;
+
+  @ApiProperty({
+    description: 'Human-readable result message',
+    example: 'Login successful',
+  })
+  message!: string;
+}

--- a/src/common/utils/cookies.spec.ts
+++ b/src/common/utils/cookies.spec.ts
@@ -78,7 +78,9 @@ describe('clearAuthCookies', () => {
       Record<string, unknown>,
     ][];
 
-    const accessTokenCall = calls.find(([name]) => name === ACCESS_TOKEN_COOKIE);
+    const accessTokenCall = calls.find(
+      ([name]) => name === ACCESS_TOKEN_COOKIE,
+    );
     const refreshCall = calls.find(([name]) => name === REFRESH_TOKEN_COOKIE);
     const xsrfCall = calls.find(([name]) => name === XSRF_TOKEN_COOKIE);
     expect(accessTokenCall?.[1].path).toBe('/');

--- a/src/common/utils/cookies.spec.ts
+++ b/src/common/utils/cookies.spec.ts
@@ -3,6 +3,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   clearAuthCookies,
+  ACCESS_TOKEN_COOKIE,
   REFRESH_TOKEN_COOKIE,
   XSRF_TOKEN_COOKIE,
 } from './cookies';
@@ -25,7 +26,7 @@ describe('clearAuthCookies', () => {
     process.env.NODE_ENV = 'development';
   });
 
-  it('calls clearCookie for both refresh_token and XSRF-TOKEN', () => {
+  it('calls clearCookie for access_token, refresh_token, and XSRF-TOKEN', () => {
     const res = buildMockRes();
 
     clearAuthCookies(res);
@@ -34,6 +35,7 @@ describe('clearAuthCookies', () => {
       res.clearCookie as ReturnType<typeof vi.fn>
     ).mock.calls.map((c: unknown[]) => c[0]);
 
+    expect(clearedNames).toContain(ACCESS_TOKEN_COOKIE);
     expect(clearedNames).toContain(REFRESH_TOKEN_COOKIE);
     expect(clearedNames).toContain(XSRF_TOKEN_COOKIE);
   });
@@ -66,7 +68,7 @@ describe('clearAuthCookies', () => {
     expect(options.httpOnly).toBe(false);
   });
 
-  it('uses restricted path for refresh cookie and root path for XSRF cookie', () => {
+  it('uses restricted path for refresh cookie and root path for access_token and XSRF cookie', () => {
     const res = buildMockRes();
 
     clearAuthCookies(res);
@@ -76,9 +78,11 @@ describe('clearAuthCookies', () => {
       Record<string, unknown>,
     ][];
 
+    const accessTokenCall = calls.find(([name]) => name === ACCESS_TOKEN_COOKIE);
     const refreshCall = calls.find(([name]) => name === REFRESH_TOKEN_COOKIE);
     const xsrfCall = calls.find(([name]) => name === XSRF_TOKEN_COOKIE);
-    expect(refreshCall?.[1].path).toBe('/api/v1/auth');
+    expect(accessTokenCall?.[1].path).toBe('/');
+    expect(refreshCall?.[1].path).toBe('/api/v1/auth/refresh');
     expect(xsrfCall?.[1].path).toBe('/');
   });
 

--- a/src/common/utils/cookies.ts
+++ b/src/common/utils/cookies.ts
@@ -7,6 +7,9 @@
 
 import type { CookieOptions, Response } from 'express';
 
+/** Name of the httpOnly access-token cookie. */
+export const ACCESS_TOKEN_COOKIE = 'access_token';
+
 /** Name of the httpOnly refresh-token cookie. */
 export const REFRESH_TOKEN_COOKIE = 'refresh_token';
 
@@ -15,7 +18,24 @@ export const XSRF_TOKEN_COOKIE = 'XSRF-TOKEN';
 
 /** Shared cookie path. */
 const COOKIE_PATH = '/';
-const REFRESH_COOKIE_PATH = '/api/v1/auth';
+
+/** Path scoped to the refresh endpoint only — limits cookie exposure. */
+const REFRESH_COOKIE_PATH = '/api/v1/auth/refresh';
+
+export function buildAccessTokenCookieOptions(expiresAt: Date): CookieOptions {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const cookieDomain = isProduction ? '.tribehub.io' : undefined;
+
+  return {
+    httpOnly: true,
+    secure: !isDevelopment,
+    sameSite: 'lax',
+    domain: cookieDomain,
+    path: COOKIE_PATH,
+    expires: expiresAt,
+  };
+}
 
 export function buildRefreshTokenCookieOptions(expiresAt: Date): CookieOptions {
   const isProduction = process.env.NODE_ENV === 'production';
@@ -48,7 +68,8 @@ export function buildCsrfCookieOptions(expiresAt: Date): CookieOptions {
 }
 
 /**
- * Clears both the `refresh_token` and `XSRF-TOKEN` cookies from the response.
+ * Clears the `access_token`, `refresh_token`, and `XSRF-TOKEN` cookies from
+ * the response.
  *
  * The options passed to `res.clearCookie()` MUST match the options used when
  * the cookies were set; otherwise the browser will not honour the deletion.
@@ -57,6 +78,12 @@ export function buildCsrfCookieOptions(expiresAt: Date): CookieOptions {
  * flag are applied regardless of when the module was first loaded.
  */
 export function clearAuthCookies(res: Response): void {
+  res.clearCookie(ACCESS_TOKEN_COOKIE, {
+    ...buildAccessTokenCookieOptions(new Date(0)),
+    expires: undefined,
+    maxAge: 0,
+  });
+
   res.clearCookie(REFRESH_TOKEN_COOKIE, {
     ...buildRefreshTokenCookieOptions(new Date(0)),
     expires: undefined,


### PR DESCRIPTION
## Resumen

  - `POST /auth/login` establece ahora el token de acceso como cookie `httpOnly`
    (`access_token`), además de `refresh_token` y `XSRF-TOKEN` — los tokens nunca
    se exponen en el cuerpo de la respuesta
  - El cuerpo de la respuesta devuelve únicamente datos públicos del usuario
    (`id`, `username`, `email`) mediante el nuevo `LoginResponseDto`
  - `AuthService.login()` devuelve un objeto `localUser` tipado y lanza
    `UnauthorizedException` (401) en lugar de un `Error` genérico cuando Supabase
    falla
  - Corregido el scope de `REFRESH_COOKIE_PATH` de `/api/v1/auth` a
    `/api/v1/auth/refresh`
  - `clearAuthCookies()` limpia ahora también la cookie `access_token` al hacer logout

  ## Ficheros modificados

  | Fichero | Cambio |
  |---|---|
  | `src/auth/dto/login.response.dto.ts` | Nuevo — DTO de respuesta tipado con Swagger |
  | `src/auth/auth.controller.ts` | Elimina try/catch, establece 3 cookies, devuelve `LoginResponseDto` |
  | `src/auth/auth.service.ts` | Retorno tipado, campo `localUser`, `UnauthorizedException` |
  | `src/common/utils/cookies.ts` | `ACCESS_TOKEN_COOKIE`, `buildAccessTokenCookieOptions()`, fix de path |
  | `*.spec.ts` (×3) | Actualizados para el flujo de 3 cookies y la nueva forma de respuesta |

  ## Plan de pruebas

  - [ ] `pnpm run test -- auth` — todos los tests unitarios de auth pasan
  - [ ] `pnpm run test -- cookies` — tests de la utilidad de cookies pasan
  - [ ] `POST /auth/login` con credenciales válidas → cuerpo con `id`, `username`,
    `email`; DevTools del navegador muestra 3 cabeceras `Set-Cookie`
  - [ ] `POST /auth/login` con contraseña incorrecta → 401 `Unauthorized`
  - [ ] `POST /auth/logout` → las 3 cookies se eliminan correctamente
  - [ ] `pnpm run lint` — sin errores

  Closes #41