### PR TITLE
feat: (#90) persist refresh token rotation — complete repo tests and fix TTL sync

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model RefreshToken {
 
   @@index([userId])
   @@index([replacedByTokenId])
+  @@index([expiresAt])
   @@map("refresh_tokens")
 }
 

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -72,6 +72,7 @@ describe('AuthController', () => {
         email: 'test@gmail.com',
       },
       csrfToken: 'csrf-token-abc',
+      refreshExpiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     });
     const req = {
       ip: '127.0.0.1',

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -40,9 +40,6 @@ import { CsrfGuard } from '../common/guards/csrf.guard';
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  private readonly refreshTtlMs =
-    Number(process.env.REFRESH_TOKEN_TTL_DAYS ?? '7') * 24 * 60 * 60 * 1000;
-
   constructor(private readonly authService: AuthService) {}
 
   @ApiOperation({ summary: 'Register a new user' })
@@ -116,7 +113,7 @@ export class AuthController {
       throw new UnauthorizedException('Invalid authentication response');
     }
 
-    const refreshExpiresAt = new Date(Date.now() + this.refreshTtlMs);
+    const { refreshExpiresAt } = result;
     // Supabase access tokens expire in `expires_in` seconds (default 3600).
     // Fall back to 3600 s if the field is absent.
     const accessTokenTtlMs =

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -44,11 +44,19 @@ const mockSecurityMonitor = {
   recordInvalidToken: vi.fn(),
 };
 
+const mockConfigService = {
+  get: vi.fn().mockImplementation((key: string) => {
+    if (key === 'REFRESH_TOKEN_TTL_DAYS') return '7';
+    return undefined;
+  }),
+};
+
 function buildService(): AuthService {
   return new AuthService(
     mockUsersRepository as never,
     mockAuthRepository as never,
     mockSecurityMonitor as never,
+    mockConfigService as never,
   );
 }
 
@@ -545,5 +553,6 @@ describe('AuthService.refreshSession', () => {
     ).rejects.toThrow('Unauthorized');
 
     expect(mockAuthRepository.rotateRefreshToken).not.toHaveBeenCalled();
+    expect(mockAuthRepository.revokeAllActiveUserTokens).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -213,6 +213,7 @@ describe('AuthService.login', () => {
       session: sessionData.session,
       localUser: { id: 'local-uuid-1', username: 'testuser', email: dto.email },
       csrfToken: expect.any(String) as unknown,
+      refreshExpiresAt: expect.any(Date) as unknown,
     });
     // localUser must NOT expose passwordHash
     expect(result.localUser).not.toHaveProperty('passwordHash');

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -133,6 +133,7 @@ export class AuthService {
     session: { access_token: string; refresh_token: string } | null;
     localUser: { id: string; username: string; email: string } | null;
     csrfToken: string;
+    refreshExpiresAt: Date;
   }> {
     const supabase = getSupabaseClient();
     const { email, password } = data;
@@ -147,6 +148,7 @@ export class AuthService {
 
     const refreshToken = signInData.session?.refresh_token;
     const supabaseUserId = signInData.user?.id;
+    const refreshExpiresAt = new Date(Date.now() + this.refreshTtlMs);
 
     let localUser: { id: string; username: string; email: string } | null =
       null;
@@ -165,7 +167,7 @@ export class AuthService {
           await this.authRepository.createRefreshToken({
             userId: dbUser.id,
             tokenHash: this.hashToken(refreshToken),
-            expiresAt: new Date(Date.now() + this.refreshTtlMs),
+            expiresAt: refreshExpiresAt,
             ipAddress: metadata?.ipAddress,
             userAgent: metadata?.userAgent,
           });
@@ -180,6 +182,7 @@ export class AuthService {
       } | null,
       localUser,
       csrfToken: this.generateCsrfToken(),
+      refreshExpiresAt,
     };
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -206,6 +206,7 @@ export class AuthService {
       throw new UnauthorizedException('Unauthorized');
     }
 
+    // A revoked or expired token signals possible token reuse — aggressively revoke all sessions for this user.
     if (
       existingToken.revokedAt ||
       existingToken.expiresAt.getTime() <= Date.now()

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import {
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as argon2 from 'argon2';
 import { createHash, randomBytes } from 'crypto';
 
@@ -27,14 +28,21 @@ import { SecurityMonitorService } from '../observability/alerts/security-monitor
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
-  private readonly refreshTtlMs =
-    Number(process.env.REFRESH_TOKEN_TTL_DAYS ?? '7') * 24 * 60 * 60 * 1000;
+  private readonly refreshTtlMs: number;
 
   constructor(
     private readonly usersRepository: UsersRepository,
     private readonly authRepository: AuthRepository,
     private readonly securityMonitor: SecurityMonitorService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.refreshTtlMs =
+      Number(this.configService.get('REFRESH_TOKEN_TTL_DAYS') ?? '7') *
+      24 *
+      60 *
+      60 *
+      1000;
+  }
 
   async register(data: RegisterRequestDto) {
     const { email, password, username } = data;
@@ -206,7 +214,6 @@ export class AuthService {
       throw new UnauthorizedException('Unauthorized');
     }
 
-    // A revoked or expired token signals possible token reuse — aggressively revoke all sessions for this user.
     if (
       existingToken.revokedAt ||
       existingToken.expiresAt.getTime() <= Date.now()

--- a/src/auth/repositories/auth.repository.spec.ts
+++ b/src/auth/repositories/auth.repository.spec.ts
@@ -168,6 +168,47 @@ describe('AuthRepository', () => {
   });
 
   describe('rotateRefreshToken', () => {
+    it('creates the new token and revokes the old one with replacedByTokenId', async () => {
+      const newTokenRecord: RefreshTokenRecord = {
+        id: 'new-token-id',
+        userId: 'user-1',
+        tokenHash: 'new-hash',
+        revokedAt: null,
+        revocationReason: null,
+        replacedByTokenId: null,
+        expiresAt: new Date(Date.now() + 60_000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ipAddress: null,
+        userAgent: null,
+      };
+      mockPrismaRefreshToken.create.mockResolvedValue(newTokenRecord);
+      mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await repository.rotateRefreshToken({
+        currentTokenId: 'old-token-id',
+        currentTokenHash: 'old-hash',
+        newTokenHash: 'new-hash',
+        userId: 'user-1',
+        newExpiresAt: new Date(Date.now() + 60_000),
+      });
+
+      expect(result).toEqual(newTokenRecord);
+
+      expect(mockPrismaRefreshToken.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'old-token-id',
+          tokenHash: 'old-hash',
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: expect.any(Date) as unknown,
+          revocationReason: 'rotation',
+          replacedByTokenId: 'new-token-id',
+        },
+      });
+    });
+
     it('throws when the old token was already revoked by a concurrent request', async () => {
       mockPrismaRefreshToken.create.mockResolvedValue({ id: 'new-token-id' });
       mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 0 });
@@ -181,6 +222,38 @@ describe('AuthRepository', () => {
           newExpiresAt: new Date(Date.now() + 60_000),
         }),
       ).rejects.toBeInstanceOf(RefreshTokenRotationConflictError);
+    });
+  });
+
+  describe('revokeAllActiveUserTokens', () => {
+    it('revokes all active tokens for a userId with the provided reason', async () => {
+      mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 3 });
+
+      const before = new Date();
+      await repository.revokeAllActiveUserTokens('user-1', 'reuse_detected');
+      const after = new Date();
+
+      expect(mockPrismaRefreshToken.updateMany).toHaveBeenCalledOnce();
+
+      const arg = mockPrismaRefreshToken.updateMany.mock.calls[0][0] as {
+        where: { userId: string; revokedAt: null };
+        data: { revokedAt: Date; revocationReason: string };
+      };
+      expect(arg.where.userId).toBe('user-1');
+      expect(arg.where.revokedAt).toBeNull();
+      expect(arg.data.revocationReason).toBe('reuse_detected');
+      expect(arg.data.revokedAt.getTime()).toBeGreaterThanOrEqual(
+        before.getTime(),
+      );
+      expect(arg.data.revokedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('does not throw when no active tokens exist for the user (count: 0)', async () => {
+      mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        repository.revokeAllActiveUserTokens('user-no-tokens', 'reuse_detected'),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/auth/repositories/auth.repository.spec.ts
+++ b/src/auth/repositories/auth.repository.spec.ts
@@ -252,7 +252,10 @@ describe('AuthRepository', () => {
       mockPrismaRefreshToken.updateMany.mockResolvedValue({ count: 0 });
 
       await expect(
-        repository.revokeAllActiveUserTokens('user-no-tokens', 'reuse_detected'),
+        repository.revokeAllActiveUserTokens(
+          'user-no-tokens',
+          'reuse_detected',
+        ),
       ).resolves.toBeUndefined();
     });
   });


### PR DESCRIPTION
Closes #90

## Qué incluye

**Tests faltantes en `AuthRepository`** (`src/auth/repositories/auth.repository.spec.ts`)
- `rotateRefreshToken` — happy path: verifica que se crea el nuevo token, se revoca el anterior con `revocationReason:
'rotation'` y `replacedByTokenId` apuntando al nuevo registro.
- `revokeAllActiveUserTokens` — nuevo `describe` con dos casos: revocación exitosa de múltiples tokens y no-op cuando no hay tokens activos.

**Eliminación de duplicación de TTL** (`src/auth/auth.service.ts`, `src/auth/auth.controller.ts`, `src/auth/auth.service.spec.ts`)
- `REFRESH_TOKEN_TTL_DAYS` se calculaba de forma independiente en `AuthService` (para `expiresAt` del registro en DB) y en `AuthController` (para `expires` de la cookie), con riesgo de desincronización.
- `AuthService.login` ahora computa `refreshExpiresAt` una sola vez y lo expone en el retorno; el controller lo consume directamente.

## Tests

Test Files  31 passed (31)
Tests       256 passed (256)